### PR TITLE
Update whitenoise, make it serve /public and add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-Agent: *
+
+Disallow: /admin/
+Disallow: /django-admin/
+
+Allow: /

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-debug-toolbar==1.2.2
 
 # Production dependencies
 dj-database-url==0.3.0
-whitenoise==2.0.4
+whitenoise==3.2.1
 ConcurrentLogHandler==0.9.1
 
 # Fix for html5lib issue, see https://github.com/torchbox/wagtail/issues/2843, fixed in Wagtail 1.4.6 and 1.5.3

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -63,6 +63,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 ]

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -157,6 +157,10 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
 
+# Serve /public directory with whitenoise
+WHITENOISE_ROOT = os.path.join(BASE_DIR, 'public')
+
+
 # Django compressor settings
 # http://django-compressor.readthedocs.org/en/latest/settings/
 

--- a/tbx/wsgi.py
+++ b/tbx/wsgi.py
@@ -9,11 +9,9 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 
 import os
 
-from whitenoise.django import DjangoWhiteNoise
-
 from django.core.wsgi import get_wsgi_application
 
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tbx.settings.production")
 
-application = DjangoWhiteNoise(get_wsgi_application())
+application = get_wsgi_application()


### PR DESCRIPTION
The `public` folder is used to place files that should be served at a specific URL, such as `favicon.ico` and `robots.txt`. It already gets served automatically by nginx on torchbox servers so this PR will not change anything there. This PR makes this folder get served in development as well.

I need this in order to disallow robots from indexing demo.wagtail.io (as that uses whitenoise to serve all static)
