### PR TITLE
Reduce size of blog thumbnails on the homepage

### DIFF
--- a/tbx/core/templates/torchbox/tags/blog_list_item.html
+++ b/tbx/core/templates/torchbox/tags/blog_list_item.html
@@ -3,7 +3,7 @@
 <li {% if post.colour %}class="{{ post.colour }}"{% endif %}>
     <a class="block-link" href="{% pageurl post %}">
         <div class="content">
-            {% image post.feed_image fill-1200x700 as background %}
+            {% image post.feed_image fill-764x448 as background %}
             <div class="image-container" {% if not post.colour %}style="background-image: url('{{ background.url }}');"{% endif %}></div>
             <div class="blog-text">
                 <div id="author" class="author clearfix" >


### PR DESCRIPTION
Currently, some images in the blog feed are over 2MB, but they are being displayed much smaller than their actual size.