### PR TITLE
Keep pip up to date and don't run migrate on initial build

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -15,13 +15,15 @@ set +e
 su - vagrant -c "createdb $PROJECT_NAME"
 set -e
 
-# Replace previous line with this if you are using Python 2
+
+# Set up virtual environment
 su - vagrant -c "virtualenv --python=python3 $VIRTUALENV_DIR"
 
 su - vagrant -c "echo $PROJECT_DIR > $VIRTUALENV_DIR/.project"
 
 
 # Install PIP requirements
+su - vagrant -c "$PIP install pip --upgrade"
 su - vagrant -c "$PIP install -r $PROJECT_DIR/requirements.txt"
 
 # Install Fabric 2

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -15,15 +15,19 @@ set +e
 su - vagrant -c "createdb $PROJECT_NAME"
 set -e
 
-
 # Set up virtual environment
 su - vagrant -c "virtualenv --python=python3 $VIRTUALENV_DIR"
 
 su - vagrant -c "echo $PROJECT_DIR > $VIRTUALENV_DIR/.project"
 
 
+# Upgrade PIP itself
+su - vagrant -c "$PIP install --upgrade pip"
+
+# Upgrade setuptools (for example html5lib needs 1.8.5+)
+su - vagrant -c "$PIP install --upgrade six setuptools"
+
 # Install PIP requirements
-su - vagrant -c "$PIP install pip --upgrade"
 su - vagrant -c "$PIP install -r $PROJECT_DIR/requirements.txt"
 
 # Install Fabric 2


### PR DESCRIPTION
Updating pip keeps away annoying warning messages and probably makes installs faster.

Running migrate on initial build is pointless unless you plan on writing content from scratch.