### PR TITLE
Removes npm scripts from initial provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .idea/
 node_modules*
 /None
+/npm-debug.log

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/argon

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ We recommend running Wagtail in a virtual machine using Vagrant, to ensure that 
 ### Installation
 
 Run the following commands:
-	
-```
+
+```bash
 git clone [the url you copied above]
 cd wagtail-torchbox
 vagrant up
@@ -28,7 +28,19 @@ vagrant ssh
 ./manage.py runserver 0.0.0.0:8000
 ```
 
-This will make the app accessible on the host machine as http://localhost:8000/ - you can access the Wagtail admin interface at http://localhost:8000/admin/. The codebase is located on the host
+To build static files you will additionally need to run the following commands:
+
+```bash
+npm install
+npm run build:prod
+```
+
+**Note:** You can run it within the VM where node is pre-installed, but if you are using Mac OS, you will likely have issues with performance of these commands. It is adviced to Mac OS users to have node on the host machine.
+
+To install node on the host machine we recommend using [`nvm`](https://github.com/creationix/nvm). Once you have `nvm` installed simply run `nvm install` to install and activate the version of node required for the project. Refer to the nvm docs for more details about available commands.
+
+
+After the installation the app will accessible on the host machine as http://localhost:8000/ - you can access the Wagtail admin interface at http://localhost:8000/admin/. The codebase is located on the host
 machine, exported to the VM as a shared folder; code editing and Git operations will generally be done on the host.
 
 To make code changes:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -60,10 +60,3 @@ EOF
 # Install node.js and npm
 curl -sSL https://deb.nodesource.com/setup_4.x | bash -
 apt-get install -y nodejs
-
-# Build the static files
-if [ -d "$PROJECT_DIR/node_modules" ]; then
-    rm -rf "$PROJECT_DIR/node_modules"
-fi
-su - vagrant -c "cd $PROJECT_DIR; npm install"
-su - vagrant -c "cd $PROJECT_DIR; npm run build:prod"


### PR DESCRIPTION
Mac OS users are having issues running `npm install` within the VM across the shared folders, so this PR:

* Removes `npm` commands from provision scripts to speed up first `vagrant up` for Mac OS 
* Adds docs on how to install required version of `nodejs` on the host machine

We will still have `nodejs` installed in the VM, so users will have a choice where to run npm: inside the VM or on the host machine.