### PR TITLE
Prevent double-escaping HTML entities in Twitter description

### DIFF
--- a/tbx/core/templates/torchbox/base.html
+++ b/tbx/core/templates/torchbox/base.html
@@ -18,7 +18,7 @@
         <meta name="twitter:site" content="@torchbox">
         <meta name="twitter:creator" content="@torchbox">
         <meta name="twitter:title" content="{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %} | Torchbox">
-        <meta name="twitter:description" content="{% if self.intro %}{{ self.intro|striptags }}{% elif self.search_description %}{{ self.search_description }}{% endif %}">
+        <meta name="twitter:description" content="{% if self.intro %}{{ self.intro|striptags|safe }}{% elif self.search_description %}{{ self.search_description }}{% endif %}">
         <meta name="twitter:image:src" content="{% if self.feed_image %}{% image self.feed_image width-400 as img %}{{ img.url }}{% else %}{% static "images/about-placeholder6.jpg" %}{% endif %}" />
 
         <meta property="fb:app_id" content="995117193836517" />


### PR DESCRIPTION
The `|striptags` filter leaves HTML entities such as `&#x27;` unchanged, and doesn't mark its output as HTML-safe, so the output ends up being double-escaped as `&amp;#27;`. This causes some consumers (specifically Slack) to display the entity in escaped form.

The double-escaping can be seen on this blog post: https://torchbox.com/blog/were-supporting-google-nasa-oxfam-nhs-wagtail-now-we-can-support-you-too/

([the Django docs](https://docs.djangoproject.com/en/2.1/ref/templates/builtins/#striptags) explicitly say not to do this, but `self.intro` is as trusted as any other bit of rich text content in Wagtail, so I believe it's a legitimate thing to do here...)