### PR TITLE
Fix error when fetching case studies related to the services pages

### DIFF
--- a/tbx/graphql/schema.py
+++ b/tbx/graphql/schema.py
@@ -374,6 +374,7 @@ class ServicePageObjectType(graphene.ObjectType):
         featured = [
             featured_pages[featured_id]
             for featured_id in featured_ids
+            if featured_id in featured_pages
         ]
 
         if self.service is not None:


### PR DESCRIPTION
It's probably due to non-public and non-live case studies being saved on the services page