### PR TITLE
[202] Serialize rich text page links

### DIFF
--- a/tbx/graphql/streamfield.py
+++ b/tbx/graphql/streamfield.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from bs4 import BeautifulSoup
 from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail.core.rich_text import RichText
@@ -7,8 +8,6 @@ from wagtail.embeds.blocks import EmbedBlock
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
 from wagtail.images.blocks import ImageChooserBlock
-
-from bs4 import BeautifulSoup
 
 
 class StreamFieldSerialiser:

--- a/tbx/graphql/streamfield.py
+++ b/tbx/graphql/streamfield.py
@@ -79,11 +79,9 @@ class StreamFieldSerialiser:
         for anchor in soup.find_all('a'):
             if anchor.attrs.get('linktype', '') == 'page':
                 try:
-                    pages = (Page.objects.select_related('content_type')
-                                         .live()
-                                         .public())
+                    pages = Page.objects.live().public()
                     page = pages.get(pk=anchor.attrs['id']).specific
-                    page_type = page.content_type.model_class().__name__
+                    page_type = page.__class__.__name__
 
                     new_tag = soup.new_tag(
                         'a',


### PR DESCRIPTION
https://projects.torchbox.com/projects/tbxcom-redesign/tickets/202

Pass slug, service slug and page type so that the links on the Gatsby front-end can be created.

It is required by front-end - torchbox/torchbox-frontend#91