### PR TITLE
Upgrade Wagtail to 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,12 +22,12 @@ django-debug-toolbar==1.2.2
 
 # Production dependencies
 dj-database-url==0.5.0
-whitenoise==3.3.1
+whitenoise==5.0.1
 ConcurrentLogHandler==0.9.1
 
 # Wagtail-markdown
 # Pinned because there is no recent pypi release available
 -e git://github.com/torchbox/wagtail-markdown.git@621bb2411ab37886bc444d44d19c3bcf1e48d0f6#egg=wagtail-markdown
-Pygments==2.1.3  # for code highlighting in wagtail-markdown
-wagtailfontawesome==1.1.3
+Pygments==2.5.2  # for code highlighting in wagtail-markdown
+wagtailfontawesome==1.2.1
 scout-apm==1.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
 wagtail==2.8
-Pillow==4.3.0
+Pillow==7.0.0
 embedly==0.5.0
 requests==2.20.0
 raven==6.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
-wagtail==2.5.2
+wagtail==2.6.3
 Pillow==4.3.0
 embedly==0.5.0
 requests==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
 wagtail==2.8
-Pillow==7.0.0
+Pillow==6.2.2
 embedly==0.5.0
 requests==2.20.0
 raven==6.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-Django==2.2.9
+Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
-wagtail==2.4
+wagtail==2.5.2
 Pillow==4.3.0
 embedly==0.5.0
 requests==2.20.0
 raven==6.9.0
 wagtail-django-recaptcha==1.0
-django-basic-auth-ip-whitelist==0.2
+django-basic-auth-ip-whitelist==0.2.1
 boto3==1.7.82
 django-storages==1.6.6
 -e git://github.com/wagtail/wagtail-review.git@8ec5ec188ee75a075bd83c3a7804aeac9abf71be#egg=wagtail-review
@@ -26,8 +26,8 @@ whitenoise==3.3.1
 ConcurrentLogHandler==0.9.1
 
 # Wagtail-markdown
-# Wagtail 2.0 compatible version
-wagtail-markdown==0.5
+# Pinned because there is no recent pypi release available
+-e git://github.com/torchbox/wagtail-markdown.git@621bb2411ab37886bc444d44d19c3bcf1e48d0f6#egg=wagtail-markdown
 Pygments==2.1.3  # for code highlighting in wagtail-markdown
 wagtailfontawesome==1.1.3
 scout-apm==1.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
-wagtail==2.7.1
+wagtail==2.8
 Pillow==4.3.0
 embedly==0.5.0
 requests==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,7 @@ whitenoise==5.0.1
 ConcurrentLogHandler==0.9.1
 
 # Wagtail-markdown
-# Pinned because there is no recent pypi release available
--e git://github.com/torchbox/wagtail-markdown.git@621bb2411ab37886bc444d44d19c3bcf1e48d0f6#egg=wagtail-markdown
+wagtail-markdown==0.6
 Pygments==2.5.2  # for code highlighting in wagtail-markdown
 wagtailfontawesome==1.2.1
 scout-apm==1.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.2.10
 psycopg2==2.7.4
 django-redis==4.10.0
-wagtail==2.6.3
+wagtail==2.7.1
 Pillow==4.3.0
 embedly==0.5.0
 requests==2.20.0

--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -6,7 +6,7 @@ from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (FieldPanel, InlinePanel,
                                          MultiFieldPanel, PageChooserPanel,
                                          StreamFieldPanel)
-from wagtail.admin.utils import send_mail
+from wagtail.admin.mail import send_mail
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.core.blocks import PageChooserBlock, StreamBlock, StructBlock
 from wagtail.core.fields import RichTextField, StreamField

--- a/tbx/core/wagtail_hooks.py
+++ b/tbx/core/wagtail_hooks.py
@@ -6,7 +6,8 @@ from storages.backends.s3boto3 import S3Boto3Storage
 from wagtail.contrib.modeladmin.options import (ModelAdmin, ModelAdminGroup,
                                                 modeladmin_register)
 from wagtail.core import hooks
-from wagtail.documents.models import document_served, get_document_model
+from wagtail.documents import get_document_model
+from wagtail.documents.models import document_served
 
 from tbx.sign_up_form.models import SignUpFormPageResponse
 

--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -107,7 +107,7 @@ class CulturePageLink(Orderable):
     description = models.TextField()
     link = models.ForeignKey('wagtailcore.Page', on_delete=models.CASCADE, blank=True, null=True)
 
-    content_panels = [
+    panels = [
         FieldPanel('title', classname="full"),
         FieldPanel('description', classname="full"),
         PageChooserPanel('link')


### PR DESCRIPTION
This PR will upgrade the following:
- Wagtail to 2.8, fixed a few deprecations and other minor issues.
- Django to 2.2.10
- Pillow to ~~7.0.0~~ 6.2.2, this one does not have a clear upgrade guide but appears to be working just fine.
- Pygments to 2.5.2, this fixes some deprecation warnings with Django.
- Whitenoise to 5.0.1, this (again) fixes some deprecation warnings with Django.
- wagtailfontawesome to 1.2.1, this (yet again) fixes some deprecation warnings with Django.
- wagtail-markdown, there is no recent compatible release available on pypi so I pinned it to the most recent commit on github.

I tested if anything broke by clicking around in the wagtail admin interface and by building the frontend. No issues there.

#190 and #187 can be closed after merging this.
