### PR TITLE
Change cors origns to .netlify.app

### DIFF
--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -457,7 +457,7 @@ GRAPHENE = {
 
 
 CORS_URLS_REGEX = r'^(\/graphql\/.*)|(\/review\/api\/.*)$'
-CORS_ORIGIN_WHITELIST = ['https://torchbox.com', 'https://tbx-production.netlify.com', 'https://tbx-staging.netlify.com']
+CORS_ORIGIN_WHITELIST = ['https://torchbox.com', 'https://tbx-production.netlify.app', 'https://tbx-staging.netlify.app']
 CORS_ALLOW_HEADERS = default_headers + (
     'x-review-token',
 )


### PR DESCRIPTION
Netlify recently changed their domains from `torchbox-production.netlify.com` to `torchbox-production.netlify.app`

This updates the CORS when using preview