### PR TITLE
bump wagtail to 2.9 and django to 2.2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-Django==2.2.12
+Django==2.2.13
 psycopg2==2.7.4
 django-redis==4.10.0
-wagtail==2.8.1
-Pillow==6.2.2
+wagtail==2.9
 embedly==0.5.0
 requests==2.20.0
 raven==6.9.0

--- a/tbx/core/templates/torchbox/base.html
+++ b/tbx/core/templates/torchbox/base.html
@@ -23,7 +23,8 @@
 
         <meta property="fb:app_id" content="995117193836517" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://{{ request.site.hostname }}{{ self.url }}" />
+        {% wagtail_site as site%}
+        <meta property="og:url" content="https://{{ site.hostname }}{{ self.url }}" />
         <meta property="og:title" content="{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %} | Torchbox" />
         <meta property="og:image" content="{% if self.feed_image %}{% image self.feed_image width-1024 as img %}{{ img.url }}{% endif %}" />
         <meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% endif %}" />

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -101,7 +101,6 @@ MIDDLEWARE = [
     # Must be placed above anything that can generate a response
     'corsheaders.middleware.CorsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 


### PR DESCRIPTION
[Wagtail 2.9 release notes](https://docs.wagtail.io/en/v2.9/releases/2.9.html)

[Django 2.2.13 release notes](https://docs.djangoproject.com/en/3.0/releases/2.2.13/)

Most important change in the Wagtail 2.9 release in the deprecation of the `SiteMiddleware` which provides `request.site`. We don't actively use the site middleware anyway because the project is headless.

Removed Pillow as a pinned dependency. Wagtail 2.9 provides version constraints for Pillow.