### PR TITLE
bump psycopg2 to 2.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.12
-psycopg2==2.7.4
+psycopg2==2.8.5
 django-redis==4.10.0
 wagtail==2.8.1
 Pillow==6.2.2


### PR DESCRIPTION
[Psycopg2 2.8 release notes
](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-8)
This prevents the following UserWarning from occuring:

> /home/vagrant/.virtualenvs/torchbox/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)

You can see this warning every time you change a file and django reloads. It's annoying.