### PR TITLE
Redesign 2020: Expose Homepage fields

### DIFF
--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -227,6 +227,8 @@ class HomePageClient(Orderable, RelatedLink):
 
 
 class HomePage(Page):
+    template = "patterns/pages/home/home_page.html"
+
     hero_intro_primary = models.TextField(blank=True)
     hero_intro_secondary = models.TextField(blank=True)
     intro_body = RichTextField(blank=True)

--- a/tbx/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/tbx/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -1,11 +1,33 @@
 {% extends "patterns/base_page.html" %}
-{% load wagtailcore_tags wagtailimages_tags static %}
+{% load static wagtailcore_tags wagtailimages_tags %}
 
 {% block content %}
+
+    {# Page title #}
     <h1>{{ page.title }}</h1>
 
-    {{ page.strapline }}
+    {# Introduction / Hero #}
+    <section>
+        <h2>
+            {{ page.hero_intro_primary }}
+            {{ page.hero_intro_secondary }}
+        </h2>
+        {{ page.intro_body|richtext }}
+    </section>
 
-    {% include "patterns/molecules/cta/call_to_action.html" with call_to_action=page.call_to_action %}
+    {# Clients #}
+    <section>
+        <h2>{{ page.clients_title }}</h2>
+    </section>
+
+    {# Works #}
+    <section>
+        <h2>{{ page.works_title }}</h2>
+    </section>
+
+    {# Blog #}
+    <section>
+        <h2>{{ page.blog_title }}</h2>
+    </section>
 
 {% endblock %}

--- a/tbx/project_styleguide/templates/patterns/pages/home/home_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/home/home_page.yaml
@@ -1,9 +1,9 @@
 context:
   page:
+    blog_title: Thinking
+    clients_title: Clients
+    hero_intro_primary: This is the hero intro primary
+    hero_intro_secondary: This is the hero intro secondary
+    intro_body: '<p>This is the intro body</p>'
     title: Homepage
-    strapline: This is a home page
-    call_to_action:
-      title: Stub content
-      summary: Check out our awesome stub content
-      get_link_text: Click here
-      get_link_url: '#'
+    work_title: Works


### PR DESCRIPTION
No Codebase ticket yet, I think the homepage is being [redesigned](https://projects.torchbox.com/projects/tbxcom/tickets/276) before work is done on it.

This PR just exposes the current homepage fields and makes sure the model looks for the new HTML file than an HTML file under `templates/home/homepage.html`.