### PR TITLE
Remove CORS headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ django-storages==1.6.6
 -e git://github.com/wagtail/wagtail-review.git@8ec5ec188ee75a075bd83c3a7804aeac9abf71be#egg=wagtail-review
 django-phonenumber-field==2.1.0
 phonenumbers==8.10.3
-django-cors-headers==3.0.2
 lxml==4.5.2
 django-pattern-library==0.2.8
 wagtail-accessibility==0.2.1

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -4,7 +4,6 @@
 import os
 
 import dj_database_url
-from corsheaders.defaults import default_headers
 
 # Configuration from environment variables
 env = os.environ.copy()
@@ -73,7 +72,6 @@ INSTALLED_APPS = [
     # Temporarily disable as this is breaking page creation. See ticket #229
     # 'wagtail_review',
     'phonenumber_field',
-    'corsheaders',
 
     'django.contrib.humanize',
     'django.contrib.admin',
@@ -460,12 +458,5 @@ PATTERN_LIBRARY_TEMPLATE_DIR = os.path.join(
 # Google Tag Manager ID from env
 GOOGLE_TAG_MANAGER_ID = env.get("GOOGLE_TAG_MANAGER_ID")
 
-
-# CORS settings
-CORS_URLS_REGEX = r'^(\/review\/api\/.*)$'
-CORS_ORIGIN_WHITELIST = ['https://torchbox.com']
-CORS_ALLOW_HEADERS = default_headers + (
-    'x-review-token',
-)
 
 SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -97,10 +97,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-    # Must be placed above anything that can generate a response
-    'corsheaders.middleware.CorsMiddleware',
-
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/tbx/settings/dev.py
+++ b/tbx/settings/dev.py
@@ -30,8 +30,6 @@ PREVIEW_URL = 'http://localhost:8003/preview/'
 
 MEDIA_PREFIX = BASE_URL
 
-CORS_ORIGIN_ALLOW_ALL = True
-
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
To fix CORS errors on staging:

```
  File "/app/tbx/settings/base.py", line 7, in <module>

    from corsheaders.defaults import default_headers

ModuleNotFoundError: No module named 'corsheaders'

The command '/bin/sh -c SECRET_KEY=none python manage.py collectstatic --noinput --clear' returned a non-zero code: 1
```

We don't use corsheaders in wagtail-kit so it should be fine to remove.

Also, from Tom U.: "OK just checked, yes you can safely remove line 7, 76 and 464-469 from https://github.com/torchbox/wagtail-torchbox/blob/redesign-2020/tbx/settings/base.py"