### PR TITLE
#273 use the strapline field to render the page title

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/title-block/title-block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/title-block/title-block.html
@@ -4,11 +4,7 @@
         {% if item.client %}
         <p class="title-block__client">{{ item.client }}</p>
         {% endif %}
-        {% if item.strapline %}
-        <h1 class="title-block__heading">{{ item.strapline|richtext }}</h1>
-        {% else %}
-        <h1 class="title-block__heading">{{ item.title }}</h1>
-        {% endif %}
+        <h1 class="title-block__heading">{% if item.strapline %}{{ item.strapline|richtext }}{% else %}{{ item.title }}{% endif %}</h1>
         {% if meta %}
         <div class="title-block__meta">
             {{ meta }}

--- a/tbx/project_styleguide/templates/patterns/molecules/title-block/title-block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/title-block/title-block.html
@@ -1,9 +1,14 @@
+{% load wagtailcore_tags %}
 <div class="title-block">
     <div class="title-block__container">
         {% if item.client %}
         <p class="title-block__client">{{ item.client }}</p>
         {% endif %}
+        {% if item.strapline %}
+        <h1 class="title-block__heading">{{ item.strapline|richtext }}</h1>
+        {% else %}
         <h1 class="title-block__heading">{{ item.title }}</h1>
+        {% endif %}
         {% if meta %}
         <div class="title-block__meta">
             {{ meta }}
@@ -16,5 +21,5 @@
             {% endfor %}
         </div>
         {% endif %}
-    </div>  
-</div>  
+    </div>
+</div>


### PR DESCRIPTION
Ticket:
https://projects.torchbox.com/projects/tbxcom/tickets/273

Fix the Person Index Page use the wrong field to render the page title issue.

![Screen Shot 2021-01-25 at 12 11 10 PM](https://user-images.githubusercontent.com/73645085/105660635-6abac680-5f06-11eb-9e17-e4f55d7ddfa9.png)
