### PR TITLE
[318/225] Use max instead of fill on SF image blocks

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
@@ -6,7 +6,7 @@
     {% elif value.alignment == 'right' %}streamfield__aligned-image--wrap-right
     {% endif %}"
 >
-    {% image value.image fill-730x490 as aligned_image %}
+    {% image value.image max-730x490 as aligned_image %}
     <img src="{{ aligned_image.url }}" alt="{{ aligned_image.alt }}" height="{{ aligned_image.height }}" width="{{ aligned_image.width }}" loading="lazy" />
     {% if value.caption %}
         <div class="streamfield__aligned-image-caption">

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/wide_image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/wide_image_block.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
 <div class="streamfield__wide-image">
-    {% image value.image fill-1600x900 as wide_image %}
+    {% image value.image max-1600x900 as wide_image %}
     <img src="{{ wide_image.url }}" alt="{{ wide_image.alt }}" height="{{ wide_image.height }}" width="{{ wide_image.width }}" loading="lazy" />
 </div>


### PR DESCRIPTION
Fixes issue with image cropping on SF blocks.

Codebase ticket [here](https://projects.torchbox.com/projects/tbxcom/tickets/318).