### PR TITLE
Careers page streamfields

### DIFF
--- a/tbx/project_styleguide/templates/patterns/pages/culture/culture_page.html
+++ b/tbx/project_styleguide/templates/patterns/pages/culture/culture_page.html
@@ -1,7 +1,7 @@
 {% extends "patterns/base_page.html" %}
 
 {% load wagtailcore_tags wagtailimages_tags static %}
-{% block theme_class %}theme--dark--transparent{% endblock %}
+{% block theme_class %}theme--dark--transparent template__careers-page{% endblock %}
 
 {% block content %}
 {% image page.hero_image width-1920 as hero_image %}

--- a/tbx/static_src/sass/abstracts/_variables.scss
+++ b/tbx/static_src/sass/abstracts/_variables.scss
@@ -92,7 +92,7 @@ $breakpoints: ('medium' '(min-width: 599px)', 'large' '(min-width: 1023px)');
 
 // Wrappers
 $site-width: 1280px;
-$wrapper--small: 790px;
+$wrapper--small: 840px;
 
 // Grid setup
 $grid: 20px;

--- a/tbx/static_src/sass/components/_culture.scss
+++ b/tbx/static_src/sass/components/_culture.scss
@@ -2,7 +2,7 @@
     $root: &;
 
     &__container {
-        max-width: 840px;
+        max-width: $wrapper--small;
         margin: 0 auto;
         padding: ($gutter * 2) $variable-gutter--small 0;
 

--- a/tbx/static_src/sass/components/_streamfield.scss
+++ b/tbx/static_src/sass/components/_streamfield.scss
@@ -211,4 +211,17 @@
     .template__standard & {
         margin-bottom: ($gutter * 5);
     }
+
+    .template__careers-page & {
+        &__heading {
+            max-width: $wrapper--small;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        &__paragraph {
+            max-width: $wrapper--small;
+            margin: 0 auto;
+        }
+    }
 }

--- a/tbx/static_src/sass/components/_streamfield.scss
+++ b/tbx/static_src/sass/components/_streamfield.scss
@@ -219,9 +219,16 @@
             margin-right: auto;
         }
 
+        &__intro,
         &__paragraph {
             max-width: $wrapper--small;
             margin: 0 auto;
+        }
+
+        &__intro {
+            p {
+                color: var(--color--dark-indigo);
+            }
         }
     }
 }

--- a/tbx/static_src/sass/components/_theme.scss
+++ b/tbx/static_src/sass/components/_theme.scss
@@ -72,7 +72,7 @@ Get in touch numbers:
     /* stylelint-disable selector-class-pattern  */
     &--dark--transparent {
         --color--primary: var(--color--white);
-        --color--accent: var(--color--lagoon);
+        --color--accent: var(--color--coral);
         --color--link: var(--color--dark-indigo);
         --color--underline: var(--color--coral);
         --color--hover: var(--color--white);

--- a/tbx/static_src/sass/components/_title-block.scss
+++ b/tbx/static_src/sass/components/_title-block.scss
@@ -25,7 +25,7 @@
         right: 0;
 
         #{$root}__heading {
-            max-width: 840px;
+            max-width: $wrapper--small;
             margin: 0 auto $gutter;
         }
     }


### PR DESCRIPTION
Ensures that the current streamfields work with the new widths that the careers page has brought with it. Only required for streamfield headings, paragraph and intro. 

`$wrapper--small` wasn't being used so i've repurposed it