### PR TITLE
Cache job count and add short timeout to PeopleHR query

### DIFF
--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -41,7 +41,7 @@ class PeopleHRFeed(object):
         if not url:
             return None
 
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=3)
 
         try:
             resp.raise_for_status()
@@ -49,6 +49,9 @@ class PeopleHRFeed(object):
             return len(xml_root.findall("channel/item"))
         except requests.exceptions.RequestException:
             logger.exception(f"Could not get People HR jobs feed from {url}")
+            return None
+        except requests.exceptions.Timeout:
+            logger.exception(f"Timed out getting People HR jobs feed from {url}")
             return None
         except ElementTree.ParseError:
             logger.exception(f"Could not parse People HR jobs feed from {url}")

--- a/tbx/core/context_processors.py
+++ b/tbx/core/context_processors.py
@@ -16,7 +16,7 @@ def peoplehr_jobs_count(request):
     Add the number of open jobs to the context
     """
     CACHE_KEY = "job_count"
-    CACHE_TIMEOUT = 21600
+    CACHE_TIMEOUT = 60 * 60 * 6
 
     job_count = cache.get(CACHE_KEY)
 


### PR DESCRIPTION
Resolve issues with PeopleHR job count requests by:

* Caching the job count
* Adding a short timeout to the external requests and handling it gracefully