### PR TITLE
[333] Culture naming

### DIFF
--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -102,8 +102,9 @@ class CulturePageLink(Orderable):
     ]
 
 
+# Was previously the culture page until it was re-purposed to be the careers page
 class CulturePage(Page):
-    template = "patterns/pages/culture/culture_page.html"
+    template = "patterns/pages/careers/careers_page.html"
 
     strapline = models.TextField()
     strapline_visible = models.BooleanField(

--- a/tbx/project_styleguide/templates/patterns/organisms/mobile-nav/mobile-nav.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/mobile-nav/mobile-nav.html
@@ -18,8 +18,8 @@
                     </a>
                 </li>
                 <li class="mobile-nav-item">
-                    <a class="mobile-nav-item__link" href="/culture-and-jobs/">
-                        <div class="mobile-nav-item__title">Culture + jobs
+                    <a class="mobile-nav-item__link" href="/careers/">
+                        <div class="mobile-nav-item__title">Careers
                             {% if job_count %}
                                 {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                             {% endif %}

--- a/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.html
+++ b/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.html
@@ -1,22 +1,22 @@
 {% extends "patterns/base_page.html" %}
 
 {% load wagtailcore_tags wagtailimages_tags static %}
-{% block theme_class %}theme--dark--transparent template__careers-page{% endblock %}
+{% block theme_class %}theme--dark--transparent{% endblock %}
 
 {% block content %}
 {% image page.hero_image width-1920 as hero_image %}
 
-<div class="culture">
+<div class="careers">
     {# Hero #}
-    <div class="culture__hero">
+    <div class="careers__hero">
         {% include "patterns/molecules/hero/full_page_hero.html" with background_url=hero_image.url classes="hero__full-screen--short" %}
         {% include "patterns/molecules/title-block/title-block.html" with title=page.strapline classes="title-block--transparent title-block--careers" %}
     </div>
 
-    <div class="culture__container culture__container--top">
+    <div class="careers__container careers__container--top">
         {# Intro #}
         {% if page.intro %}
-            <div class="culture__rich-text">
+            <div class="careers__rich-text">
                 {{ page.intro|richtext }}
             </div>
         {% endif %}
@@ -31,9 +31,9 @@
 
     {# Benefits list #}
     {% if page.benefits_section_title %}
-        <div class="culture__container culture__container--middle">
-            <h2 class="culture__title">{{ page.benefits_section_title }}</h2>
-            <ul class="culture__benefits-list">
+        <div class="careers__container careers__container--middle">
+            <h2 class="careers__title">{{ page.benefits_section_title }}</h2>
+            <ul class="careers__benefits-list">
                 {% for item in page.key_benefits.all %}
                     {% include "patterns/molecules/list-item/list-item.html" with item=item %}
                 {% endfor %}
@@ -42,7 +42,7 @@
     {% endif %}
 
     {# Card links #}
-    <div class="culture__container culture__container--bottom">
+    <div class="careers__container careers__container--bottom">
         {% include "patterns/organisms/card-listing/card-listing.html" with card_items=page.links.all classes="card-listing--single" %}
     </div>
 

--- a/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.yaml
@@ -1,7 +1,7 @@
 context:
   page:
-    title: Culture Page
-    get_verbose_name: culture-page
+    title: Careers
+    get_verbose_name: careers-page
     strapline_visible: true
     strapline: We're 100% <br><span class="title-block__span">employee owned <span><span class="title-block__second-span">.</span>
     intro: >-

--- a/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/careers/careers_page.yaml
@@ -3,7 +3,7 @@ context:
     title: Careers
     get_verbose_name: careers-page
     strapline_visible: true
-    strapline: We're 100% <br><span class="title-block__span">employee owned <span><span class="title-block__second-span">.</span>
+    strapline: We're 100% <br><span>employee owned</span>.
     intro: >-
       <p>We've always been mission driven. Now we have enshrined our values in our company structure, making all our employees equal owners. <b>Work for a company that works for you and have a real stake in our future.</b></p>
     links:

--- a/tbx/static_src/sass/components/_careers.scss
+++ b/tbx/static_src/sass/components/_careers.scss
@@ -1,4 +1,4 @@
-.culture {
+.careers {
     $root: &;
 
     &__container {

--- a/tbx/static_src/sass/components/_title-block.scss
+++ b/tbx/static_src/sass/components/_title-block.scss
@@ -8,14 +8,6 @@
         #{$root}__heading {
             color: var(--color--white);
         }
-
-        #{$root}__span {
-            color: var(--color--coral);
-        }
-
-        #{$root}__second-span {
-            color: var(--color--white);
-        }
     }
 
     &--careers {

--- a/tbx/static_src/sass/main.scss
+++ b/tbx/static_src/sass/main.scss
@@ -26,7 +26,7 @@
 @import 'components/client-item';
 @import 'components/contact-block';
 @import 'components/cookie-message';
-@import 'components/culture';
+@import 'components/careers';
 @import 'components/error-hero';
 @import 'components/filter';
 @import 'components/footer';


### PR DESCRIPTION
https://projects.torchbox.com/projects/tbxcom/tickets/333

Updates:
- mobile nav to include careers page
- culture page template and css class names to careers
- how the heading colours work on the careers page - any `<span>` of `.title-block__heading` uses the color-accent var so we can just use that rather than overwrite. 