### PR TITLE
Unregister all service workers

### DIFF
--- a/tbx/static_src/javascript/main.js
+++ b/tbx/static_src/javascript/main.js
@@ -10,10 +10,10 @@ import InPageNav from './components/in-page-nav';
 
 import '../sass/main.scss';
 
-navigator.serviceWorker.getRegistrations().then(function(registrations) {
-    for(let registration of registrations) {
+navigator.serviceWorker.getRegistrations().then(function (registrations) {
+    registrations.forEach(function (registration) {
         registration.unregister();
-    }
+    });
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/tbx/static_src/javascript/main.js
+++ b/tbx/static_src/javascript/main.js
@@ -10,6 +10,12 @@ import InPageNav from './components/in-page-nav';
 
 import '../sass/main.scss';
 
+navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for(let registration of registrations) {
+        registration.unregister();
+    }
+});
+
 document.addEventListener('DOMContentLoaded', () => {
     /* eslint-disable no-new, no-restricted-syntax */
 

--- a/tbx/static_src/javascript/main.js
+++ b/tbx/static_src/javascript/main.js
@@ -10,11 +10,13 @@ import InPageNav from './components/in-page-nav';
 
 import '../sass/main.scss';
 
-navigator.serviceWorker.getRegistrations().then(function (registrations) {
-    registrations.forEach(function (registration) {
-        registration.unregister();
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function (registrations) {
+        registrations.forEach(function (registration) {
+            registration.unregister();
+        });
     });
-});
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     /* eslint-disable no-new, no-restricted-syntax */


### PR DESCRIPTION
Some users still have the old Gatsby service worker registered which is causing various strange caching issues.

This forces all service workers to be unregistered when a users visits the site.