### PR TITLE
Fix: Media and dump dir in containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     tty: true
     volumes:
       - ./media:/app/media:delegated,rw
-      - ./database_dumps:/database_dumps:delegated,rw
+      - ./database_dumps:/app/database_dumps:delegated,rw
     command: tail -f /dev/null
 
   db:
@@ -92,7 +92,7 @@ services:
     logging:
       driver: none
     volumes:
-      - ./database_dumps:/database_dumps:delegated,rw
+      - ./database_dumps:/app/database_dumps:delegated,rw
 
   redis:
     image: redis:3.0

--- a/fabfile.py
+++ b/fabfile.py
@@ -140,20 +140,23 @@ def npm(c, command, daemonise=False):
 
 
 @task
-def psql(c):
+def psql(c, command=None):
     """
     Connect to the local postgres DB using psql
     """
-    subprocess.run(
-        [
-            "docker-compose",
-            "exec",
-            "db",
-            "psql",
-            f"-d{LOCAL_DATABASE_NAME}",
-            f"-U{LOCAL_DATABASE_USERNAME}",
-        ]
-    )
+    cmd_list = [
+        "docker-compose",
+        "exec",
+        "db",
+        "psql",
+        *["-d", LOCAL_DATABASE_NAME],
+        *["-U", LOCAL_DATABASE_USERNAME],
+    ]
+
+    if command:
+        cmd_list.extend(["-c", command])
+
+    subprocess.run(cmd_list)
 
 
 # TODO check the rest of these work correctly from here down
@@ -197,15 +200,7 @@ def import_data(c, database_filename):
 
 
 def delete_local_renditions(c, local_database_name=LOCAL_DATABASE_NAME):
-    try:
-        psql(c, "DELETE FROM images_rendition;")
-    except Exception:
-        pass
-
-    try:
-        psql(c, "DELETE FROM wagtailimages_rendition;")
-    except Exception:
-        pass
+    psql(c, "DELETE FROM images_rendition;")
 
 
 #########

--- a/fabfile.py
+++ b/fabfile.py
@@ -28,6 +28,7 @@ LOCAL_MEDIA_FOLDER = "{0}/media".format(PROJECT_DIR)
 LOCAL_IMAGES_FOLDER = "{0}/media/original_images".format(PROJECT_DIR)
 LOCAL_DATABASE_NAME = PROJECT_NAME = "tbx"
 LOCAL_DATABASE_USERNAME = "tbx"
+LOCAL_DATABASE_DUMPS_FOLDER = "{0}/database_dumps".format(PROJECT_DIR)
 
 
 ############
@@ -488,16 +489,16 @@ def pull_database_from_heroku(c, app_instance):
     datestamp = datetime.datetime.now().isoformat(timespec="seconds")
 
     dexec(
-        "heroku pg:backups:download --output=/database_dumps/{datestamp}.dump --app {app}".format(
-            app=app_instance, datestamp=datestamp
+        "heroku pg:backups:download --output={database_dumps}/{datestamp}.dump --app {app}".format(
+            database_dumps=LOCAL_DATABASE_DUMPS_FOLDER, app=app_instance, datestamp=datestamp
         ),
         service="utils",
     )
 
-    import_data(c, f"/database_dumps/{datestamp}.dump")
+    import_data(c, f"{LOCAL_DATABASE_DUMPS_FOLDER}/{datestamp}.dump")
 
     dexec(
-        "rm /database_dumps/{datestamp}.dump".format(datestamp=datestamp,),
+        "rm {database_dumps}/{datestamp}.dump".format(database_dumps=LOCAL_DATABASE_DUMPS_FOLDER, datestamp=datestamp),
         service="utils",
     )
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,8 +24,8 @@ PRODUCTION_APP_INSTANCE = "cms-torchbox-com"
 STAGING_APP_INSTANCE = "torchbox-staging"
 DEVELOPMENT_APP_INSTANCE = ""
 
-LOCAL_MEDIA_FOLDER = "media"
-LOCAL_IMAGES_FOLDER = "media/original_images"
+LOCAL_MEDIA_FOLDER = "{0}/media".format(PROJECT_DIR)
+LOCAL_IMAGES_FOLDER = "{0}/media/original_images".format(PROJECT_DIR)
 LOCAL_DATABASE_NAME = PROJECT_NAME = "tbx"
 LOCAL_DATABASE_USERNAME = "tbx"
 


### PR DESCRIPTION
I was having issues with pulling staging images and data. 

It turned out that the directories mounted on the `utils` container belonged to the `root` user because they where placed in the filesystem root. 

I have adjusted the paths to mount these directories in the `/app` directory (`/app/media` and `/app/database_dumps`). Now these directories can be written by the `tbx` user in the `utils` container (which is the default user that is running the fab commands). 