### PR TITLE
Fix blog posts on Careers page

### DIFF
--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -200,13 +200,21 @@ class BlogPage(Page):
     @property
     def related_blog_posts(self):
         services = self.related_services.all()
-        return (
-            BlogPage.objects.filter(related_services__in=services)
+
+        # format for template
+        return [
+            {
+                "title": blog_post.title,
+                "url": blog_post.url,
+                "author": blog_post.first_author,
+                "date": blog_post.date,
+            }
+            for blog_post in BlogPage.objects.filter(related_services__in=services)
             .live()
             .distinct()
             .order_by("-first_published_at")
             .exclude(pk=self.pk)[:2]
-        )
+        ]
 
     @property
     def blog_index(self):

--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -77,7 +77,9 @@ class PersonPage(Page):
                 "author": blog_post.first_author,
                 "date": blog_post.date,
             }
-            for blog_post in BlogPage.objects.filter(authors__author=author_snippet).order_by("-date")
+            for blog_post in BlogPage.objects.filter(
+                authors__author=author_snippet
+            ).order_by("-date")
         ]
 
 

--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -68,7 +68,17 @@ class PersonPage(Page):
     def author_blogs(self):
         # return the blogs writen by this member
         author_snippet = Author.objects.get(person_page__pk=self.pk)
-        return BlogPage.objects.filter(authors__author=author_snippet).order_by("-date")
+
+        # format for template
+        return [
+            {
+                "title": blog_post.title,
+                "url": blog_post.url,
+                "author": blog_post.first_author,
+                "date": blog_post.date,
+            }
+            for blog_post in BlogPage.objects.filter(authors__author=author_snippet).order_by("-date")
+        ]
 
 
 # Person index

--- a/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.html
+++ b/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.html
@@ -35,7 +35,7 @@
         {% endfor %}
     </div>
 
-    {% if page.related_blog_posts.exists %}
+    {% if page.related_blog_posts %}
         <div class="page__showcase">
             <div class="blog-listing blog-listing--top-space">
                 <div class="blog-listing__content">
@@ -43,7 +43,7 @@
                 </div>
                 <div class="blog-listing__content">
                     <div class="blog-listing__list blog-listing__list--horizontal">
-                        {% for blog in page.related_blog_posts.all %}
+                        {% for blog in page.related_blog_posts %}
                             {% include "patterns/molecules/blog-item/blog-item.html" with item=blog %}
                         {% endfor %}
                     </div>


### PR DESCRIPTION
The format for blog posts was changed in https://github.com/torchbox/wagtail-torchbox/pull/312. This PR formats the data for the latest posts on the:

- Blog detail page
- Person detail page