### PR TITLE
Fix: Command to delete image rendition in fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -200,7 +200,7 @@ def import_data(c, database_filename):
 
 
 def delete_local_renditions(c, local_database_name=LOCAL_DATABASE_NAME):
-    psql(c, "DELETE FROM images_rendition;")
+    psql(c, "DELETE FROM torchbox_torchboxrendition;")
 
 
 #########


### PR DESCRIPTION
Because the app is using a custom rendition model, the command needed to be adjusted from the command in Wagtail kit (which I had just recently copied over here).