### PR TITLE
use interactive heroku login not the browser one

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -433,7 +433,7 @@ def heroku_login(c):
     """
     Log into the Heroku app for accessing config vars, database backups etc.
     """
-    subprocess.call(["docker-compose", "exec", "utils", "heroku", "login"])
+    subprocess.call(["docker-compose", "exec", "utils", "heroku", "login", "-i"])
 
 
 def check_if_logged_in_to_heroku(c):


### PR DESCRIPTION
use interactive heroku login not the browser one when running fab heroku-login - this is now conisstent with what is in wagtail-kit