### PR TITLE
[359] Aligned image SF quality

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
@@ -6,7 +6,11 @@
     {% elif value.alignment == 'right' %}streamfield__aligned-image--wrap-right
     {% endif %}"
 >
-    {% image value.image max-730x490 as aligned_image %}
+    {% if value.alignment == 'full' %}
+        {% image value.image max-1280x860 as aligned_image %}
+    {% else %}
+        {% image value.image max-730x490 as aligned_image %}
+    {% endif %}
     <img src="{{ aligned_image.url }}" alt="{{ aligned_image.alt }}" height="{{ aligned_image.height }}" width="{{ aligned_image.width }}" loading="lazy" />
     {% if value.caption %}
         <div class="streamfield__aligned-image-caption">


### PR DESCRIPTION
https://projects.torchbox.com/projects/tbxcom/tickets/359

The aligned image streamfield is currently outputting images at `max-730x490` and is set to be `max-width: 50vw;` which means they are very pixelated when used on a blog page and viewed on a wide screen. 

This MR resolves that by increasing the size of the image when the alignment option is set to full width.

(click the gif below to open in a new tab and see the difference in image quality)

![tbx-align-image-sf](https://user-images.githubusercontent.com/31627284/127351575-4b64b50c-8297-46c4-93c4-b5c930a33abc.gif)
