### PR TITLE
[362] Order job listing alphabetically

### DIFF
--- a/tbx/project_styleguide/templates/patterns/pages/job/job_listing.html
+++ b/tbx/project_styleguide/templates/patterns/pages/job/job_listing.html
@@ -15,7 +15,7 @@
 
             <div class="job-listing__list">
                 {% if feed_success %}
-                    {% for job in jobs %}
+                    {% for job in jobs|dictsort:"title" %}
                         {% include "patterns/molecules/job-item/job-item.html" with item=job %}
                     {% endfor %}
                 {% else %}


### PR DESCRIPTION
Opened a blank ticket ([362](https://projects.torchbox.com/projects/tbxcom/tickets/362)) to track this.

We should probably order the list on the BE after pulling the data via the PeopleHR API, but this is ok for now I think.