### PR TITLE
Homepage video image

### DIFF
--- a/tbx/static_src/javascript/components/shards-video.js
+++ b/tbx/static_src/javascript/components/shards-video.js
@@ -17,6 +17,7 @@ class ShardsVideo {
         if (window.matchMedia('(min-width: 1023px)').matches) {
             this.videoSource.src = this.videoSource.getAttribute('data-src');
             this.video.load();
+            this.node.classList.add('video-loaded');
         }
     }
 
@@ -27,6 +28,11 @@ class ShardsVideo {
             } else {
                 this.video.pause();
             }
+        });
+
+        // Show a fallback image if the video fails to load
+        this.videoSource.addEventListener('error', () => {
+            this.node.classList.add('video-error');
         });
     }
 }

--- a/tbx/static_src/javascript/components/shards-video.js
+++ b/tbx/static_src/javascript/components/shards-video.js
@@ -17,7 +17,6 @@ class ShardsVideo {
         if (window.matchMedia('(min-width: 1023px)').matches) {
             this.videoSource.src = this.videoSource.getAttribute('data-src');
             this.video.load();
-            this.node.classList.add('video-loaded');
         }
     }
 

--- a/tbx/static_src/sass/components/_responsive-object.scss
+++ b/tbx/static_src/sass/components/_responsive-object.scss
@@ -21,6 +21,12 @@
         @include media-query(large) {
             padding-bottom: 56.255%;
             background-position: -1px center;
+            background-size: 0;
+
+            // Show a fallback image if the video fails to load
+            .video-error & {
+                background-size: cover;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently the hero image is shown on mobile and desktop even though it's not used on desktop - this means you see a flash of the image before the video loads. This MR hides the image by default and only shows it if the video fails to load.
