### PR TITLE
Use `get` to access `job_count` in context

### DIFF
--- a/tbx/navigation/templatetags/navigation_tags.py
+++ b/tbx/navigation/templatetags/navigation_tags.py
@@ -13,7 +13,7 @@ def primarynav(context, is_home):
         "primarynav": context["settings"]["navigation"][
             "NavigationSettings"
         ].primary_navigation,
-        "job_count": context["job_count"],
+        "job_count": context.get("job_count", 0),
         "request": request,
         "is_home": is_home,
     }


### PR DESCRIPTION
I was getting "KeyError" on all pages when working locally. I assume
because the API access to retrieve the job count is not setup correctly.

I have now protected the key access with `get` so that the access fails
more gracefully.