### PR TITLE
Make the request as part of the exception handling

### DIFF
--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -41,9 +41,9 @@ class PeopleHRFeed(object):
         if not url:
             return None
 
-        resp = requests.get(url, timeout=3)
-
         try:
+            resp = requests.get(url, timeout=3)
+
             resp.raise_for_status()
             xml_root = ElementTree.fromstring(resp.content)
             return len(xml_root.findall("channel/item"))


### PR DESCRIPTION
This ensure that read timeouts are also captured, as these would be captured _before_ `raise_for_exception` is called.