### PR TITLE
Improve handling of location fields from PeopleHR jobs feed

### DIFF
--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -23,12 +23,19 @@ class PeopleHRFeed(object):
 
         for node in xml_root.iter("item"):
             job = {}
-
             job["title"] = node.find("vacancyname").text
             job["description"] = node.find("vacancydescription").text
             job["department"] = node.find("department").text
-            job["location"] = node.find("city").text
             job["link"] = node.find("link").text
+
+            # Not all postings include all location fields: ensure any provided are used
+            location = []
+            for location_key in ['city', 'country']:
+                try:
+                    location.append(node.find(location_key).text)
+                except AttributeError:
+                    pass
+            job["location"] = ', '.join(location)
 
             jobs.append(job)
 

--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -30,12 +30,12 @@ class PeopleHRFeed(object):
 
             # Not all postings include all location fields: ensure any provided are used
             location = []
-            for location_key in ['city', 'country']:
+            for location_key in ["city", "country"]:
                 try:
                     location.append(node.find(location_key).text)
                 except AttributeError:
                     pass
-            job["location"] = ', '.join(location)
+            job["location"] = ", ".join(location)
 
             jobs.append(job)
 


### PR DESCRIPTION
For [Support ticket 305](https://projects.torchbox.com/projects/support-team/tickets/305)

https://torchbox.com/jobs/ is currently broken, as one of the vacancies coming from the PeopleHR feed doesn't contain a `city` attribute which the code assumes will be present.

I've amended the code so that it will use either/both of the `city` and `country` attributes if present, and an empty string if neither are supplied.