### PR TITLE
Add fallback content if PeopleHR job listing fields are forgotten

### DIFF
--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -33,7 +33,9 @@ class PeopleHRFeed(object):
             try:
                 job["description"] = node.find("vacancydescription").text
             except AttributeError:
-                job["description"] = "This role is currently being considered and will be announced shortly."
+                job[
+                    "description"
+                ] = "This role is currently being considered and will be announced shortly."
 
             try:
                 job["link"] = node.find("link").text

--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -23,10 +23,27 @@ class PeopleHRFeed(object):
 
         for node in xml_root.iter("item"):
             job = {}
-            job["title"] = node.find("vacancyname").text
-            job["description"] = node.find("vacancydescription").text
-            job["department"] = node.find("department").text
-            job["link"] = node.find("link").text
+
+            # Provide a generic fallback content if the job creator forgets to include it
+            try:
+                job["title"] = node.find("vacancyname").text
+            except AttributeError:
+                job["title"] = "Role to be Announced"
+
+            try:
+                job["description"] = node.find("vacancydescription").text
+            except AttributeError:
+                job["description"] = "This role is currently being considered and will be announced shortly."
+
+            try:
+                job["link"] = node.find("link").text
+            except AttributeError:
+                job["link"] = "mailto://recruitment@torchbox.com"
+
+            try:
+                job["department"] = node.find("department").text
+            except AttributeError:
+                job["department"] = "TBC"
 
             # Not all postings include all location fields: ensure any provided are used
             location = []

--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -25,7 +25,14 @@ class PeopleHRFeed(object):
             job = {}
 
             try:
-                job["title"] = node.find("vacancyname").text
+                try:
+                    job["title"] = node.find("vacancyname").text
+                except AttributeError:
+                    logger.exception(
+                        f"A job added to PeopleHR is missing a title, it will not show on the live site."
+                    )
+                    continue
+
                 job["description"] = node.find("vacancydescription").text
                 job["link"] = node.find("link").text
                 job["department"] = node.find("department").text
@@ -41,7 +48,7 @@ class PeopleHRFeed(object):
                 jobs.append(job)
             except AttributeError:
                 logger.exception(
-                    f"A job added to PeopleHR is missing field data, it will not show on the live site: {node}"
+                    f"A job added to PeopleHR is missing field data, it will not show on the live site: {job['title']}"
                 )
 
         return jobs

--- a/tbx/core/api.py
+++ b/tbx/core/api.py
@@ -24,39 +24,25 @@ class PeopleHRFeed(object):
         for node in xml_root.iter("item"):
             job = {}
 
-            # Provide a generic fallback content if the job creator forgets to include it
             try:
                 job["title"] = node.find("vacancyname").text
-            except AttributeError:
-                job["title"] = "Role to be Announced"
-
-            try:
                 job["description"] = node.find("vacancydescription").text
-            except AttributeError:
-                job[
-                    "description"
-                ] = "This role is currently being considered and will be announced shortly."
-
-            try:
                 job["link"] = node.find("link").text
-            except AttributeError:
-                job["link"] = "mailto://recruitment@torchbox.com"
-
-            try:
                 job["department"] = node.find("department").text
+
+                location = []
+                for location_key in ["city", "country"]:
+                    try:
+                        location.append(node.find(location_key).text)
+                    except AttributeError:
+                        pass
+                job["location"] = ", ".join(location)
+
+                jobs.append(job)
             except AttributeError:
-                job["department"] = "TBC"
-
-            # Not all postings include all location fields: ensure any provided are used
-            location = []
-            for location_key in ["city", "country"]:
-                try:
-                    location.append(node.find(location_key).text)
-                except AttributeError:
-                    pass
-            job["location"] = ", ".join(location)
-
-            jobs.append(job)
+                logger.exception(
+                    f"A job added to PeopleHR is missing field data, it will not show on the live site: {node}"
+                )
 
         return jobs
 


### PR DESCRIPTION
This should prevent the `/jobs` page from crashing if information from the PeopleHR feed is forgotten. I've added generic placeholder content for each field, please double check the copy I've used. 

I think that peopleHR is set up so that the link should always be present, as this isn't a user editable field. If peopleHR crashes or the feed breaks, I've added a mailto link that directs to recruitment@torchbox.com. Alternatively we could add a link that redirects to a 404 page, but in this scenario, it's less likely someone will reach out to contact us about the issue.