### PR TITLE
increase minor node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as frontend
+FROM node:14.15 as frontend
 
 # Make build & post-install scripts behave as if we were in a CI environment (e.g. for logging verbosity purposes).
 ARG CI=true

--- a/dockerfiles/Dockerfile.frontend
+++ b/dockerfiles/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.15
 
 WORKDIR /home/node
 USER node


### PR DESCRIPTION
These fixes bump the minor node version which fails in docker-compose as it resolves to a lower version than is built in production.  