### PR TITLE
Team member meta info spacing

### DIFF
--- a/tbx/static_src/sass/components/_author.scss
+++ b/tbx/static_src/sass/components/_author.scss
@@ -33,6 +33,12 @@
         @include font-size(xxxs);
         line-height: 1.4;
         margin: 0 0 0;
+        display: flex;
+        flex-direction: column;
+
+        @include media-query(medium) {
+            display: block;
+        }
     }
 
     &__role {
@@ -45,25 +51,21 @@
         font-weight: bold;
     }
 
-    &__date {
-        @include font-size(xxxs);
-        text-transform: none;
-        letter-spacing: 0;
-        color: var(--color--grey);
-        margin-left: 5px;
-        padding-left: 5px;
-        border-left: 1px solid rgba(var(--color--black), 0.1);
-    }
-
+    &__date,
     &__readtime {
         @include font-size(xxxs);
         text-transform: none;
         letter-spacing: 0;
         color: var(--color--grey);
-        margin-left: 5px;
-        padding-left: 5px;
         border-left: 1px solid rgba(var(--color--black), 0.1);
 
+        @include media-query(medium) {
+            margin-left: 5px;
+            padding-left: 5px;
+        }
+    }
+
+    &__readtime {
         .page__author & {
             display: none;
         }
@@ -71,6 +73,10 @@
 
     &__tags {
         margin: 10px 0 0;
+    }
+
+    &__avatar {
+        flex-shrink: 0;
     }
 
     .page & {


### PR DESCRIPTION
Ensure team image doesn't get squashed and stack meta items on mob

<details>
<summary>Before:</summary>

![Screenshot 2022-04-04 at 15 40 25](https://user-images.githubusercontent.com/31627284/161572020-3eb22ed8-200e-45f6-b069-9ef0c9236a84.png)

</details>

<details>
<summary>After:</summary>

![Screenshot 2022-04-04 at 15 50 50](https://user-images.githubusercontent.com/31627284/161572090-856c490b-6c1c-439c-89d4-2a9d65bdab5b.png)

</details>