### PR TITLE
Remove fixed height for embeds

### DIFF
--- a/tbx/static_src/sass/components/_streamfield.scss
+++ b/tbx/static_src/sass/components/_streamfield.scss
@@ -51,18 +51,6 @@
             width: 100%;
             height: 100%;
         }
-
-        iframe {
-            height: 250px;
-
-            @include media-query(medium) {
-                height: 350px;
-            }
-
-            @include media-query(large) {
-                height: 400px;
-            }
-        }
     }
 
     &__paragraph {


### PR DESCRIPTION
Embeds iframes are being given a fixed height meaning they look short on wide monitors. This code was added back when the project was being setup (https://github.com/torchbox/wagtail-torchbox/commit/d6b528aaf1874c9799b4b3ef0bd3e1c8270516e4#diff-3a047d6ba09721cdf2c7ef25d4bb2cfe2257e6eff5c733bf65438c6fc19181eaR52) so I think it's legacy and can be removed. 

<details>
<summary>Before: </summary>

![Screenshot 2022-04-04 at 16 26 23](https://user-images.githubusercontent.com/31627284/161578350-b2cb2570-3586-415f-bc92-3e865a104b98.png)

</details>

<details>
<summary>After: </summary>

![Screenshot 2022-04-04 at 16 26 38](https://user-images.githubusercontent.com/31627284/161578411-b320f0e3-ba72-4813-ac50-46e78b19c309.png)

</details>