### PR TITLE
Fix Job Badge Consistency Across Site

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/navigation/primary-nav.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/navigation/primary-nav.html
@@ -8,7 +8,8 @@
                 <span class="nav-item__title">{% firstof link.title link.page.title %}</span>
             </a>
             {% if link.page.slug == 'jobs' and job_count > 0 %}
-                <a class="nav-item__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available">
+                <a class="nav-item__badge" href="/careers/jobs/" tabindex="-1">
+                    <span class="badge__description">{{ job_count }} jobs available</span>
                     {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                 </a>
             {% endif %}
@@ -39,7 +40,8 @@
                         {% firstof link.title link.page.title %}
                     </a>
                     {% if link.page.slug == 'jobs' and job_count > 0 %}
-                        <a class="subnav__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available" role="img">
+                        <a class="subnav__badge" href="/careers/jobs/" tabindex="-1">
+                            <span class="badge__description">{{ job_count }} jobs available</span>
                             {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                         </a>
                     {% endif %}
@@ -60,7 +62,8 @@
                 <span class="nav-item__title">{% firstof link.title link.page.title %}</span>
             </a>
             {% if link.page.slug == 'jobs' and job_count > 0 %}
-                <a class="nav-item__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available" role="img">
+                <a class="nav-item__badge" href="/careers/jobs/" tabindex="-1">
+                    <span class="badge__description">{{ job_count }} jobs available</span>
                     {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                 </a>
             {% endif %}

--- a/tbx/project_styleguide/templates/patterns/molecules/navigation/primary-nav.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/navigation/primary-nav.html
@@ -8,7 +8,7 @@
                 <span class="nav-item__title">{% firstof link.title link.page.title %}</span>
             </a>
             {% if link.page.slug == 'jobs' and job_count > 0 %}
-                <a class="nav-item__badge-link" href="/careers/jobs/" aria-label="{{ job_count }} jobs available">
+                <a class="nav-item__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available">
                     {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                 </a>
             {% endif %}
@@ -39,7 +39,7 @@
                         {% firstof link.title link.page.title %}
                     </a>
                     {% if link.page.slug == 'jobs' and job_count > 0 %}
-                        <a class="subnav__badge-link" data-subnav-badge-link href="/careers/jobs/" aria-label="{{ job_count }} jobs available">
+                        <a class="subnav__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available" role="img">
                             {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                         </a>
                     {% endif %}
@@ -60,7 +60,7 @@
                 <span class="nav-item__title">{% firstof link.title link.page.title %}</span>
             </a>
             {% if link.page.slug == 'jobs' and job_count > 0 %}
-                <a class="nav-item__badge-link" href="/careers/jobs/" aria-label="{{ job_count }} jobs available">
+                <a class="nav-item__badge" href="/careers/jobs" tabindex="-1" aria-label="{{ job_count }} jobs available" role="img">
                     {% include "patterns/atoms/badge/badge.html" with total=job_count %}
                 </a>
             {% endif %}

--- a/tbx/static_src/javascript/components/primary-nav.js
+++ b/tbx/static_src/javascript/components/primary-nav.js
@@ -11,7 +11,6 @@ class PrimaryNav {
         this.button = node.querySelector('[data-subnav-button]');
         this.overlay = node.querySelector('[data-subnav-background-overlay]');
         this.navLinks = node.querySelectorAll('[data-subnav-link]');
-        this.badgeLinks = node.querySelectorAll('[data-subnav-badge-link]');
         this.lastNavLink = this.navLinks[this.navLinks.length - 1];
         this.navLinkKeyEvents = [];
 
@@ -116,14 +115,6 @@ class PrimaryNav {
             // Log keydown all throughout the menu items as at any point in the list the user
             // can press and hold shift and start going back up through menu items
             this.navLinks[i].addEventListener('keydown', navLinkKeyLogger);
-        }
-
-        // As we can tab to badges, we have to listen for keyboard events on them as well
-        // There was a bug of holding shift and tabbing back to the badge, then releasing shift and tabbing forwards
-        // as a result, the menu wouldn't close as it thinks the user is still holding shift
-        for (let i = 0; i < this.badgeLinks.length; i += 1) {
-            this.badgeLinks[i].addEventListener('keyup', navLinkKeyRemover);
-            this.badgeLinks[i].addEventListener('keydown', navLinkKeyLogger);
         }
     }
 }

--- a/tbx/static_src/sass/abstracts/_mixins.scss
+++ b/tbx/static_src/sass/abstracts/_mixins.scss
@@ -172,3 +172,16 @@
         }
     }
 }
+
+@mixin subnav-link-underscore($height) {
+    &::after {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: #{$height}px;
+        bottom: 0;
+        left: 0;
+        background-color: var(--color--coral);
+        transition: height $transition-quick;
+    }
+}

--- a/tbx/static_src/sass/components/_badge.scss
+++ b/tbx/static_src/sass/components/_badge.scss
@@ -3,30 +3,21 @@
     @include z-index(badge);
     font-weight: 700;
     line-height: 25px;
-    color: var(--color--get-in-touch-numbers);
-    transition: color $transition;
+    color: var(--color--white);
     position: relative;
+    user-select: none;
 
     &::before {
         @include z-index(under);
         width: 18px;
         height: 22px;
         content: '';
-        background: var(--color--header-icon-color);
+        background: var(--color--coral);
         position: absolute;
         transform: translate(-50%, -25%) rotate(30deg);
         left: 50%;
         top: 0;
         transition: background $transition;
-    }
-
-    &:focus,
-    &:hover {
-        color: var(--color--accent);
-
-        &::before {
-            background: var(--color--primary);
-        }
     }
 
     &--desktop {
@@ -36,14 +27,7 @@
 
     .mobile-nav & {
         &::before {
-            top: 3px;
-        }
-    }
-
-    .theme--coral & {
-        &:focus,
-        &:hover {
-            color: var(--color--dark-indigo);
+            top: 1px;
         }
     }
 
@@ -52,13 +36,6 @@
 
         @include media-query(menu-break) {
             left: -10px;
-        }
-
-        &:focus,
-        &:hover {
-            &::before {
-                background: var(--color--dark-indigo);
-            }
         }
     }
 }

--- a/tbx/static_src/sass/components/_badge.scss
+++ b/tbx/static_src/sass/components/_badge.scss
@@ -38,4 +38,8 @@
             left: -10px;
         }
     }
+
+    &__description {
+        @include hidden();
+    }
 }

--- a/tbx/static_src/sass/components/_nav-item.scss
+++ b/tbx/static_src/sass/components/_nav-item.scss
@@ -101,7 +101,7 @@
             }
         }
 
-        &__badge-link {
+        &__badge {
             @include link-underscore(0);
             border-bottom: 0;
 
@@ -158,7 +158,7 @@
             }
         }
 
-        &__badge-link {
+        &__badge {
             width: 14px;
             text-align: center;
             border-bottom: 0;

--- a/tbx/static_src/sass/components/_subnav.scss
+++ b/tbx/static_src/sass/components/_subnav.scss
@@ -2,8 +2,6 @@
     @include z-index(two);
     border-radius: 12px;
     position: absolute;
-    // Style values taken from new careers site design
-    // https://www.figma.com/file/nTKNovsb1TY48FmDfZueov/Careers-section---Contentful?node-id=725%3A57908
     padding: 31px 20px;
     min-width: 186px;
     left: 5px;
@@ -27,7 +25,7 @@
     }
 
     &__link {
-        @include link-underscore(0);
+        @include subnav-link-underscore(0);
         font-weight: $weight--bold;
         position: relative;
         border-bottom: 0;
@@ -39,7 +37,7 @@
         &:hover,
         &:focus,
         &--active {
-            @include link-underscore(2);
+            @include subnav-link-underscore(2);
             color: var(--color--dark-indigo);
         }
     }
@@ -75,8 +73,8 @@
 
         &__badge {
             position: relative;
-            left: 10px;
-            bottom: 10px;
+            left: 20px;
+            bottom: 15px;
             border-bottom: 0;
         }
     }

--- a/tbx/static_src/sass/components/_subnav.scss
+++ b/tbx/static_src/sass/components/_subnav.scss
@@ -44,9 +44,9 @@
         }
     }
 
-    &__badge-link {
+    &__badge {
         position: relative;
-        left: 14px;
+        left: 10px;
         bottom: 10px;
         border-bottom: 0;
     }
@@ -73,9 +73,9 @@
             }
         }
 
-        &__badge-link {
+        &__badge {
             position: relative;
-            left: 20px;
+            left: 10px;
             bottom: 10px;
             border-bottom: 0;
         }


### PR DESCRIPTION
This MR updates the job badge colours and interactions to follow the careers site. The badges are clickable links, but I've removed them from the tab order as keyboard users already have the option to view the jobs page and don't need this twice.

I've removed the thematic colouring of the links for greater consistency across the site menus - this was recommended by Ben Enright.

I'm not sure about my implementation of the badge description text - this content isn't navigable through tab indexes, but I expect it will still be read aloud?

<details><summary>Screenshots</summary>
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/18164832/162251938-25705171-8fcf-4b20-98dc-6ca8211920de.png">
<img width="979" alt="image" src="https://user-images.githubusercontent.com/18164832/162252050-09542257-a66d-4a10-99a2-ae1ae98fe876.png">
<img width="696" alt="image" src="https://user-images.githubusercontent.com/18164832/162252129-19c53c0d-01e3-4848-b159-b40af06d5721.png">
</details>