### PR TITLE
Add Bold Link to Process Section

### DIFF
--- a/tbx/static_src/sass/components/_process.scss
+++ b/tbx/static_src/sass/components/_process.scss
@@ -62,6 +62,10 @@
         margin: 0 0 0;
     }
 
+    &__item-link {
+        font-weight: $weight--heavy;
+    }
+
     &__item-title,
     &__cta h2 {
         @include font-size(l);


### PR DESCRIPTION
This MR makes a minor tweak to add a bold link style to the processes section. This style now fits in with the link used in the blog page rich text.

<img width="500" alt="Screenshot 2022-04-12 at 12 19 30" src="https://user-images.githubusercontent.com/18164832/162950478-df399275-2df1-43a8-af77-ce92338685a7.png">
