### PR TITLE
Upgrade wagtail 3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1322,7 +1322,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 
 [[package]]
 name = "wagtail"
-version = "3.0rc1"
+version = "3.0rc3"
 description = "A Django content management system."
 category = "main"
 optional = false
@@ -1534,7 +1534,7 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ba052bfe380b21fc2d1905a235cbcbe725eb74b6e99c5f0a35304bf7adf491d8"
+content-hash = "ac7462c80798e047ca2f4b3cfddb7d785649c95190e27bb99e9779e34e186ace"
 
 [metadata.files]
 anyascii = [
@@ -2440,8 +2440,8 @@ virtualenv = [
     {file = "virtualenv-20.13.1.tar.gz", hash = "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"},
 ]
 wagtail = [
-    {file = "wagtail-3.0rc1-py3-none-any.whl", hash = "sha256:678a6436af49f33ef59063ff1b22d2ea74c5e7b37e1eba006ef699f05fab80e8"},
-    {file = "wagtail-3.0rc1.tar.gz", hash = "sha256:5bca2c9265e0584045904b8ce48f23119a7d4cba272cc8f9ffca819350f3276e"},
+    {file = "wagtail-3.0rc3-py3-none-any.whl", hash = "sha256:aca19977ba304f9e121ab77e8b098b0fb4f92a092bd059f6a6e00acf48c3c70f"},
+    {file = "wagtail-3.0rc3.tar.gz", hash = "sha256:c9f2b894987107625f4a87365c0f36536f3f6755154662520471d6bbb3486c03"},
 ]
 wagtail-accessibility = [
     {file = "wagtail-accessibility-0.2.1.tar.gz", hash = "sha256:70a246bfa3bc85751317633353491c2f2432bd4ed54968f89ad1406d9e4d0190"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Torchbox Ltd"]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "~3.2"
-wagtail = "3.0rc1"
+wagtail = "3.0rc3"
 psycopg2 = "~2.8"
 gunicorn = {version = "~20.0", optional = true}
 wagtail-django-recaptcha = "1.0"


### PR DESCRIPTION
# This upgrades Wagtail from v3.0rc3 to v3.0

Ticket: https://projects.torchbox.com/projects/support-team/tickets/426

Release notes: https://docs.wagtail.org/en/latest/releases/3.0.html

## Upgrade considerations

- Changes to module paths: `wagtail updatemodulepaths` has been run
- Removal of special-purpose field panel types: Changes have been made
- BASE_URL setting renamed to WAGTAILADMIN_BASE_URL: Updated
- use_json_field argument added to StreamField: Updated
- SQLite now requires the JSON1 extension enabled: We aren't using sqlite

## Upgrade considerations - deprecation of old functionality

- Removed support for Internet Explorer: noted
- Hallo legacy rich text editor has moved to an external package: not used
- Removal of legacy clean_name on AbstractFormField: not used
- Removed support for Jinja2 2.x: not used

## Upgrade considerations - changes affecting Wagtail customisations

- API changes to panels (EditHandlers): updated
- API changes to ModelAdmin: not used
- Replaced content_json TextField with content JSONField in PageRevision: checked
- Replaced data_json TextField with data JSONField in BaseLogEntry: checked
- Replaced form_data TextField with JSONField in AbstractFormSubmission: checked
- Removed size argument from wagtail.utils.sendfile_streaming_backend.was_modified_since: checked

The changes above were all considered when 3.0rc1 was upgraded. There are no new changes here.