### PR TITLE
New streamfield template for client logos

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags wagtailcore_tags %}
-<div class="client-block">
-    <div class="client-block__container">
-        {% if value.clients %}
+{% if value.clients %}
+    <div class="client-block">
+        <div class="client-block__container">
             <div class="client-block__section">
                 <ul class="client-block__icon-list client-block__icon-list--spaced">
                     {% for client in value.clients %}
@@ -15,6 +15,6 @@
                     {% endfor %}
                 </ul>
             </div>
-        {% endif %}
+        </div>
     </div>
-</div>
+{% endif %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.html
@@ -1,0 +1,20 @@
+{% load wagtailimages_tags wagtailcore_tags %}
+<div class="client-block">
+    <div class="client-block__container">
+        {% if value.clients %}
+            <div class="client-block__section">
+                <ul class="client-block__icon-list client-block__icon-list--spaced">
+                    {% for client in value.clients %}
+                        <li class="client-item">
+                            <div class="client-item__container">
+                                <a class="client-item__link" href="{% pageurl client.link %}" title="{{ client.link_title }}">
+                                    {% image client.image width-400 class="client-item__image" loading="lazy" alt="" %}
+                                </a>
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+    </div>
+</div>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/client-logo-block.yaml
@@ -1,0 +1,25 @@
+context:
+  value:
+    clients:
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+      - link_title: Title text
+        link: '#'
+
+tags:
+  image:
+    client.image width-400 class="client-item__image" loading="lazy" alt="":
+      raw: '<img src="https://placekitten.com/400/300" class="client-item__image">'
+  pageurl:
+    client.link:
+      raw: '#'

--- a/tbx/project_styleguide/templates/patterns/pages/service/service.html
+++ b/tbx/project_styleguide/templates/patterns/pages/service/service.html
@@ -17,6 +17,7 @@
         </div>
     {% endif %}
 
+    {# Note that when the service page is removed, the client-block.html and client-block.yaml under 'organisms' can be removed, as this is replaced by the new client-logo-block.html template under 'molecules/streamfield/blocks' #}
     {% if page.testimonials_section_title %}
         <div class="service-section" id="{{ page.testimonials_section_title|slugify }}" data-service-section>
             {% include "patterns/organisms/client-block/client-block.html" with title=page.testimonials_section_title clients=page.client_logos.all quotes=page.testimonials.all %}

--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -1,4 +1,5 @@
 .client-item {
+    $root: &;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -23,5 +24,14 @@
     &__image {
         width: 100%;
         height: 100%;
+
+        #{$root}__link:hover & {
+            filter: drop-shadow(2px 2px 10px var(--color--grey));
+        }
+    }
+
+    &__link {
+        display: block;
+        border: 0;
     }
 }


### PR DESCRIPTION
- Uses existing styles from the `organisms/client-block.html` template
- Adds links plus a hover effect
- Adds a title field for the link
- Adds comment that `organisms/client-block.html` could be removed when the service page is no longer needed.