### PR TITLE
Add config for security headers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -380,7 +380,7 @@ testing = ["django-modelcluster"]
 
 [[package]]
 name = "django-permissions-policy"
-version = "4.13.0"
+version = "4.14.0"
 description = "Set the draft security HTTP header Permissions-Policy (previously Feature-Policy) on your Django app."
 category = "main"
 optional = false
@@ -1813,6 +1813,10 @@ django-pattern-library = [
 django-permissionedforms = [
     {file = "django-permissionedforms-0.1.tar.gz", hash = "sha256:4340bb20c4477fffb13b4cc5cccf9f1b1010b64f79956c291c72d2ad2ed243f8"},
     {file = "django_permissionedforms-0.1-py2.py3-none-any.whl", hash = "sha256:d341a961a27cc77fde8cc42141c6ab55cc1f0cb886963cc2d6967b9674fa47d6"},
+]
+django-permissions-policy = [
+    {file = "django-permissions-policy-4.14.0.tar.gz", hash = "sha256:923db75e74b1e363c84f2a7723c4af6fd78a5baa6c7fbdb0850e5b38d88e0a06"},
+    {file = "django_permissions_policy-4.14.0-py3-none-any.whl", hash = "sha256:a0f20a2c56409126c67bb4f85ef0e51625aec6a0a02b912fda70b466fcf2c0ed"},
 ]
 django-phonenumber-field = [
     {file = "django-phonenumber-field-6.4.0.tar.gz", hash = "sha256:72a3e7a3e7493bf2a12c07a3bc77ce89813acc16592bf04d0eee3b5a452097ed"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -379,6 +379,17 @@ Django = "*"
 testing = ["django-modelcluster"]
 
 [[package]]
+name = "django-permissions-policy"
+version = "4.13.0"
+description = "Set the draft security HTTP header Permissions-Policy (previously Feature-Policy) on your Django app."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+Django = ">=3.2"
+
+[[package]]
 name = "django-phonenumber-field"
 version = "6.4.0"
 description = "An international phone number field for django models."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ whitenoise = "^6.1.0"
 dj-database-url = "^0.5.0"
 django-redis = "^5.2.0"
 django-storages = {extras = ["boto3"], version = "^1.12.3"}
-django-permissions-policy = "^4.13.0"
+django-permissions-policy = "^4.14.0"
 django-referrer-policy = "~1.0"
 django-csp = "^3.7"
 scout-apm = "^2.25.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ whitenoise = "^6.1.0"
 dj-database-url = "^0.5.0"
 django-redis = "^5.2.0"
 django-storages = {extras = ["boto3"], version = "^1.12.3"}
+django-permissions-policy = "^4.13.0"
 django-referrer-policy = "~1.0"
 django-csp = "^3.7"
 scout-apm = "^2.25.1"

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -90,12 +90,15 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django_permissions_policy.PermissionsPolicyMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    # Clickjacking prevention. Default: X_FRAME_OPTIONS = 'DENY'
+    # See https://docs.djangoproject.com/en/dev/ref/clickjacking/#preventing-clickjacking
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
@@ -417,6 +420,29 @@ if "CSP_DEFAULT_SRC" in env:
     if "CSP_OBJECT_SRC" in env:
         CSP_OBJECT_SRC = env["CSP_OBJECT_SRC"].split(",")
 
+# Permissions policy settings
+# Uses django-permissions-policy to return the header.
+# https://github.com/adamchainz/django-permissions-policy
+# The list of Chrome-supported features are in:
+# https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
+PERMISSIONS_POLICY = {
+    "accelerometer": [],
+    "ambient-light-sensor": [],
+    "autoplay": [],
+    "camera": [],
+    "display-capture": [],
+    "document-domain": [],
+    "encrypted-media": [],
+    "geolocation": [],
+    "gyroscope": [],
+    "interest-cohort": [],
+    "magnetometer": [],
+    "microphone": [],
+    "midi": [],
+    "payment": [],
+    "picture-in-picture": [],
+    "usb": [],
+}
 
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -365,11 +365,26 @@ SECURE_SSL_REDIRECT = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# This is a setting activating the HSTS header. This will enforce the visitors to use
+# HTTPS for an amount of time specified in the header. Since we are expecting our apps
+# to run via TLS by default, this header is activated by default.
+# The header can be deactivated by setting this setting to 0, as it is done in the
+# dev and testing settings.
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-hsts-seconds
+DEFAULT_HSTS_SECONDS = 30 * 24 * 60 * 60  # 30 days
+SECURE_HSTS_SECONDS = DEFAULT_HSTS_SECONDS
 if "SECURE_HSTS_SECONDS" in env:
     try:
         SECURE_HSTS_SECONDS = int(env["SECURE_HSTS_SECONDS"])
     except ValueError:
         pass
+
+# Do not use the `includeSubDomains` directive for HSTS. This needs to be prevented
+# because the apps are running on client domains (or our own for staging), that are
+# being used for other applications as well. We should therefore not impose any
+# restrictions on these unrelated applications.
+# https://docs.djangoproject.com/en/3.2/ref/settings/#secure-hsts-include-subdomains
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-browser-xss-filter
 SECURE_BROWSER_XSS_FILTER = True

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -393,6 +393,31 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 
+# Content Security policy settings
+# http://django-csp.readthedocs.io/en/latest/configuration.html
+if "CSP_DEFAULT_SRC" in env:
+    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+
+    # The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', and 'none' must be quoted!
+    # e.g.: CSP_DEFAULT_SRC = "'self'" Without quotes they will not work as intended.
+
+    CSP_DEFAULT_SRC = env["CSP_DEFAULT_SRC"].split(",")
+    if "CSP_SCRIPT_SRC" in env:
+        CSP_SCRIPT_SRC = env["CSP_SCRIPT_SRC"].split(",")
+    if "CSP_STYLE_SRC" in env:
+        CSP_STYLE_SRC = env["CSP_STYLE_SRC"].split(",")
+    if "CSP_IMG_SRC" in env:
+        CSP_IMG_SRC = env["CSP_IMG_SRC"].split(",")
+    if "CSP_CONNECT_SRC" in env:
+        CSP_CONNECT_SRC = env["CSP_CONNECT_SRC"].split(",")
+    if "CSP_FONT_SRC" in env:
+        CSP_FONT_SRC = env["CSP_FONT_SRC"].split(",")
+    if "CSP_BASE_URI" in env:
+        CSP_BASE_URI = env["CSP_BASE_URI"].split(",")
+    if "CSP_OBJECT_SRC" in env:
+        CSP_OBJECT_SRC = env["CSP_OBJECT_SRC"].split(",")
+
+
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/
 REFERRER_POLICY = env.get(

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -355,9 +355,14 @@ if "SENTRY_DSN" in env and not is_in_shell:
 
 # Security configuration
 # https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security
-if env.get("SECURE_SSL_REDIRECT", "true").strip().lower() == "true":
-    SECURE_SSL_REDIRECT = True
 
+# Force HTTPS redirect (enabled by default!)
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-ssl-redirect
+SECURE_SSL_REDIRECT = True
+
+# This will allow the cache to swallow the fact that the website is behind TLS
+# and inform the Django using "X-Forwarded-Proto" HTTP header.
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 if "SECURE_HSTS_SECONDS" in env:
@@ -366,11 +371,12 @@ if "SECURE_HSTS_SECONDS" in env:
     except ValueError:
         pass
 
-if env.get("SECURE_BROWSER_XSS_FILTER", "true").lower().strip() == "true":
-    SECURE_BROWSER_XSS_FILTER = True
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-browser-xss-filter
+SECURE_BROWSER_XSS_FILTER = True
 
-if env.get("SECURE_CONTENT_TYPE_NOSNIFF", "true").lower().strip() == "true":
-    SECURE_CONTENT_TYPE_NOSNIFF = True
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-content-type-nosniff
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
 
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -382,10 +382,7 @@ if "SECURE_HSTS_SECONDS" in env:
     except ValueError:
         pass
 
-# Do not use the `includeSubDomains` directive for HSTS. This needs to be prevented
-# because the apps are running on client domains (or our own for staging), that are
-# being used for other applications as well. We should therefore not impose any
-# restrictions on these unrelated applications.
+# We don't enforce HSTS on subdomains as anything at subdomains is likely outside our control.
 # https://docs.djangoproject.com/en/3.2/ref/settings/#secure-hsts-include-subdomains
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
@@ -428,14 +425,13 @@ if "CSP_DEFAULT_SRC" in env:
 PERMISSIONS_POLICY = {
     "accelerometer": [],
     "ambient-light-sensor": [],
-    "autoplay": [],
+    "autoplay": ["self"],
     "camera": [],
     "display-capture": [],
     "document-domain": [],
     "encrypted-media": [],
     "geolocation": [],
     "gyroscope": [],
-    "interest-cohort": [],
     "magnetometer": [],
     "microphone": [],
     "midi": [],


### PR DESCRIPTION
https://projects.torchbox.com/projects/support-team/tickets/561


### When applied, this MR will...

set up the `Strict-Transport-Security` (HSTS), `Content-Security-Policy` (CSP), and `Permissions-Policy` headers.

To do:

- Permissions Policy headers

### Please provide detail on the technical changes, if relevant

- tweak some existing config:
    - Force `SECURE_SSL_REDIRECT` as true always
    - Set up a default value of 30 days for `SECURE_HSTS_SECONDS`
- use `django-csp` and environment variables for CSP headers, and
- use `django-permissions-policy` for Permissions Policy headers.
    - I've set most of the features as disabled because it doesn't look like we need them for wagtail.org (except `fullscreen` which I left out so that we can still use full screen with youtube videos)