### PR TITLE
Fix logic for conditional revision model

### DIFF
--- a/tbx/core/utils/migrations.py
+++ b/tbx/core/utils/migrations.py
@@ -23,19 +23,23 @@ def for_each_page_revision(*model_names):
         def wrapper(apps, schema_editor):
             ContentType = apps.get_model("contenttypes.ContentType")
 
-            try:
-                PageRevision = apps.get_model("wagtailcore.Revision")
-            except LookupError:
-                # In previous versions of Wagtail, this model was `PageRevision`
-                PageRevision = apps.get_model("wagtailcore.PageRevision")
-
             content_types = [
                 ContentType.objects.get_for_model(apps.get_model(model_name))
                 for model_name in model_names
             ]
-            revisions = PageRevision.objects.filter(
-                page__content_type__in=content_types
-            )
+
+            try:
+                PageRevision = apps.get_model("wagtailcore.Revision")
+                revisions = PageRevision.objects.filter(
+                    content_type__in=content_types
+                )
+            except LookupError:
+                # In previous versions of Wagtail, this model was `PageRevision`
+                PageRevision = apps.get_model("wagtailcore.PageRevision")
+
+                revisions = PageRevision.objects.filter(
+                    page__content_type__in=content_types
+                )
 
             for revision in revisions.select_related("page"):
                 content = json.loads(revision.content_json)

--- a/tbx/core/utils/migrations.py
+++ b/tbx/core/utils/migrations.py
@@ -30,16 +30,18 @@ def for_each_page_revision(*model_names):
 
             try:
                 PageRevision = apps.get_model("wagtailcore.Revision")
-                revisions = PageRevision.objects.filter(content_type__in=content_types)
+                revisions = PageRevision.objects.filter(
+                    content_type__in=content_types
+                ).prefetch_related("content_object")
             except LookupError:
                 # In previous versions of Wagtail, this model was `PageRevision`
                 PageRevision = apps.get_model("wagtailcore.PageRevision")
 
                 revisions = PageRevision.objects.filter(
                     page__content_type__in=content_types
-                )
+                ).select_related("page")
 
-            for revision in revisions.select_related("page"):
+            for revision in revisions:
                 content = json.loads(revision.content_json)
                 new_content = fn(revision.page, content)
                 if new_content is not None:

--- a/tbx/core/utils/migrations.py
+++ b/tbx/core/utils/migrations.py
@@ -30,9 +30,7 @@ def for_each_page_revision(*model_names):
 
             try:
                 PageRevision = apps.get_model("wagtailcore.Revision")
-                revisions = PageRevision.objects.filter(
-                    content_type__in=content_types
-                )
+                revisions = PageRevision.objects.filter(content_type__in=content_types)
             except LookupError:
                 # In previous versions of Wagtail, this model was `PageRevision`
                 PageRevision = apps.get_model("wagtailcore.PageRevision")


### PR DESCRIPTION
tests fail with 

```
raise FieldError("Cannot resolve keyword '%s' into field. "
django.core.exceptions.FieldError: Cannot resolve keyword 'page' into field. Choices are: approved_go_live_at, base_content_type, base_content_type_id, content, content_type, content_type_id, created_at, created_comments, id, object_id, object_str, submitted_for_moderation, task_states, user, user_id
```

on `PageRevision.objects.filter(page__content_type__in=...)`

Ref: https://github.com/torchbox/wagtail-torchbox/actions/runs/3938884880/jobs/6738095040#step:13:56