### PR TITLE
Fix client logo styling (#415)

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/streamfield-example-proposition-page/clients-section-body.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/streamfield-example-proposition-page/clients-section-body.html
@@ -1,0 +1,16 @@
+<div class="streamfield">
+
+    {% include "patterns/molecules/streamfield/blocks/client-logo-block.html"  %}
+
+    <div class="streamfield__quote quote-slider">
+        <svg class="quote-slider__icon" width="120" height="90" aria-hidden="true">
+            <use xlink:href="#quote-icon" />
+        </svg>
+        <div class="quote-slider__slider">
+            <div class="quote-slider__slides">
+                {% include "patterns/molecules/streamfield/blocks/pullquote_block.html" with classes="pullquote--slider"  %}
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/streamfield-example-proposition-page/clients-section-body.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/streamfield-example-proposition-page/clients-section-body.yaml
@@ -1,0 +1,4 @@
+tags:
+  image:
+    client.image width-400 class="client-item__image" loading="lazy" alt="":
+      raw: '<img src="https://placekitten.com/400/300" class="client-item__image">'

--- a/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.yaml
@@ -11,8 +11,8 @@ context:
 tags:
   include_block:
     page.services_section_body:
-      template_name: 'patterns/molecules/streamfield/streamfield-example-standard.html'
+      template_name: 'patterns/molecules/streamfield/streamfield-example-team.html'
     page.clients_section_body:
-      template_name: 'patterns/molecules/streamfield/streamfield-example-standard.html'
+      template_name: 'patterns/molecules/streamfield/streamfield-example-proposition-page/clients-section-body.html'
     page.team_section_body:
-      template_name: 'patterns/molecules/streamfield/streamfield-example-standard.html'
+      template_name: 'patterns/molecules/streamfield/streamfield-example-team.html'

--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -3,21 +3,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(100% / 2);
-
-    @include media-query(medium) {
-        width: calc(100% / 3);
-    }
-
-    @include media-query(large) {
-        width: calc(100% / 6);
-    }
 
     &__container {
         padding: 15px;
 
         @include media-query(medium) {
             padding: 30px;
+        }
+
+        @include media-query(large) {
+            padding: 15px;
         }
     }
 

--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -39,22 +39,20 @@
             content: none; // don't show li arrow
         }
 
-        #{$root}__container {
-            padding: 15px 0;
-
-            @include media-query(medium) {
-                padding: 30px 0;
-            }
+        #{$root}__link:hover {
+            // don't show link underline inherited from streamfield links
+            border-bottom: 2px solid transparent;
         }
 
-        #{$root}__image {
-            height: 80px;
-            object-fit: contain;
-            max-width: 140px;
+        #{$root}__container {
+            padding: 0 15px;
 
             @include media-query(medium) {
-                height: 110px;
-                max-width: 200px;
+                padding: 0 30px;
+            }
+
+            @include media-query(large) {
+                padding: 15px;
             }
         }
     }


### PR DESCRIPTION
[Link to ticket on Codebase](https://projects.torchbox.com/projects/tbxcom/tickets/415)

The issue was caused due to an update to the client logo container element, which had been converted into a CSS grid system recently. The `client-item` children within the grid no longer need their width specified as a percentage, as the grid container will handle their width for them.

There was an issue with the streamfield version of the client logo block not resizing - I've addressed this by removing the fixed width of these logo elements.

I've updated the pattern library so you can preview the client logo block as the child of a streamfield within the propositions page. This is helpful as generic styles get applied to all the child elements of a streamfield container - if we're not careful, we'll miss the necessary resetting / overriding of these default streamfield styles while developing.

I've tweaked the padding on desktop slightly for a better final size of logos, see screenshots.

### Screenshots / Gifs

<details><summary>Screenshots</summary>
<img width="1436" alt="Screenshot 2023-02-03 at 11 17 05" src="https://user-images.githubusercontent.com/18164832/216593121-78ef2b4b-2a7d-43d7-91fb-1a8442ba2524.png">

<img width="864" alt="Screenshot 2023-02-03 at 11 18 14" src="https://user-images.githubusercontent.com/18164832/216593193-933b3744-5b99-441d-b067-b6f8540b0249.png">

<img width="497" alt="Screenshot 2023-02-03 at 11 18 53" src="https://user-images.githubusercontent.com/18164832/216593204-ffecc755-6421-4768-b958-1c3079aecaba.png">
</details>

[Gif of the client logo block in the pattern library](https://github.com/torchbox/wagtail-torchbox/files/10578872/resizing-pattern-library-template.gif.zip).