### PR TITLE
#418 - Fix Chrome logo rendering issue with image height

### DIFF
--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -18,7 +18,6 @@
 
     &__image {
         width: 100%;
-        height: 100%;
         transition: box-shadow $transition-quick;
 
         #{$root}__link:hover & {


### PR DESCRIPTION
**[Link to ticket](https://projects.torchbox.com/projects/tbxcom/tickets/418)**

Although the client logo images used in the proposition page streamfield are styled correctly in Firefox and Safari, they are stretched upwards to fill available space on Chrome.

<details><summary>Screenshots of issue</summary>
<img width="1440" alt="Screenshot 2023-02-09 at 15 31 23" src="https://user-images.githubusercontent.com/18164832/217858697-ee2097d0-c50c-43ec-8fc3-e0cd4d14bd9f.png">
<img width="1440" alt="Screenshot 2023-02-09 at 15 28 07" src="https://user-images.githubusercontent.com/18164832/217858725-f4b383b6-6d43-4837-af5d-f063829179e3.png">
</details>

This can be seen when viewing a draft proposition page in Wagtail admin, but it doesn't affect the logos on the homepage of the site. This was surprising as the markup to create both sections is identical when viewed in DevTools, and I wasn't able to find the difference in style rules applied to both elements (checked using a diff checker).

The issue can be resolved easily by removing the height 100% rule, allowing the images to fill the space automatically.

Merged with staging for testing.