### PR TITLE
Fix tota11y/doctype order

### DIFF
--- a/tbx/project_styleguide/templates/patterns/base.html
+++ b/tbx/project_styleguide/templates/patterns/base.html
@@ -1,6 +1,5 @@
 {% load static wagtailuserbar wagtailcore_tags wagtailimages_tags navigation_tags util_tags wagtailaccessibility_tags %}
 <!doctype html>
-{% tota11y %}
 <html class="{% block body_class %}template__{{ page.get_verbose_name|slugify }}{% endblock %}" lang="en-GB">
     <head>
         {% if request.in_preview_panel %}
@@ -47,6 +46,8 @@
         {% block footer %}{% endblock %}
 
         <script src="{% static 'js/main.js' %}"></script>
+
+        {% tota11y %}
 
         {% block extra_js %}{% endblock %}
     </body>

--- a/tbx/project_styleguide/templates/patterns/base.html
+++ b/tbx/project_styleguide/templates/patterns/base.html
@@ -1,6 +1,6 @@
 {% load static wagtailuserbar wagtailcore_tags wagtailimages_tags navigation_tags util_tags wagtailaccessibility_tags %}
-{% tota11y %}
 <!doctype html>
+{% tota11y %}
 <html class="{% block body_class %}template__{{ page.get_verbose_name|slugify }}{% endblock %}" lang="en-GB">
     <head>
         {% if request.in_preview_panel %}


### PR DESCRIPTION
Prevent `tota11y` including its `<script>` before the doctype (they should be the other way around). This is currently forcing Chrome to parse the page in quirks mode.

See [Slack thread](https://torchbox.slack.com/archives/C032PPZDF/p1675983186634579?thread_ts=1675959755.474629&cid=C032PPZDF) for more info.