### PR TITLE
Add Hotjar tracking in CMS admin with insert_global_admin_js

### DIFF
--- a/tbx/core/wagtail_hooks.py
+++ b/tbx/core/wagtail_hooks.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
+from django.utils.safestring import mark_safe
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -33,3 +35,30 @@ def serve_document_from_s3(document, request):
 @hooks.register("construct_settings_menu")
 def hide_main_menu_menu_item(request, menu_items):
     menu_items[:] = [item for item in menu_items if item.name != "main-menu"]
+
+
+@hooks.register("insert_global_admin_js")
+def hotjar_admin_tracking():
+    """
+    Trial Hotjar tracking for the CMS admin. Testing whether
+    this can help with Wagtail core design decisions.
+    """
+    hjid = settings.ADMIN_HOTJAR_SITE_ID
+
+    if not hjid:
+        return ""
+
+    return mark_safe(
+        f"""
+    <script>
+        (function(h,o,t,j,a,r){{
+            h.hj=h.hj||function(){{(h.hj.q=h.hj.q||[]).push(arguments)}};
+            h._hjSettings={{hjid:{hjid},hjsv:6}};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        }})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
+    """
+    )

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -563,6 +563,9 @@ PATTERN_LIBRARY_TEMPLATE_DIR = os.path.join(
 # Google Tag Manager ID from env
 GOOGLE_TAG_MANAGER_ID = env.get("GOOGLE_TAG_MANAGER_ID")
 
+# Trial Hotjar tracking for the CMS admin.
+ADMIN_HOTJAR_SITE_ID = env.get("ADMIN_HOTJAR_SITE_ID")
+
 SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
 
 # Birdbath - Database anonymisation


### PR DESCRIPTION
This is a trial of using Hotjar to track user actions in the CMS. We’re interested in this to inform changes to navigation across the site’s pages – we’ll collect data for a few weeks, and if this proves promising, endeavour to do the same type of analysis on a larger site.

To test this,

- Without any special configuration, this should do nothing.
- With a `ADMIN_HOTJAR_SITE_ID` environment variable, this should load the Hotjar tracking script.

For example:

```bash
export ADMIN_HOTJAR_SITE_ID=3367653
```

Hotjar site IDs are set up for specific domain names so this might not do anything aside from loading the script – and that’s ok.

---

Once deployed in Heroku, we will use config vars to track with the correct Hotjar account, and to turn this off once it’s no longer needed.