### PR TITLE
Fix subnav z-index

### DIFF
--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -126,7 +126,7 @@
     }
 
     &__image-mask {
-        @include z-index(header); // above in page nav to allow for overlap
+        @include z-index(zero);
         display: none;
         position: absolute;
         top: -60px;


### PR DESCRIPTION
The subnav menus was appearing under the hero image. 

I tried to put to `subnav` z-index the `nav` value (50) and `__image-mask` z-index `header` (30) but seems not 
working... 


Some page example:
I verified in other pages in this way the subnav is displayed correctly
![CleanShot 2023-03-15 at 10 41 08](https://user-images.githubusercontent.com/28976199/225289653-5aa666dd-1eaa-4e86-a809-4c3f9c071ed6.png)

![CleanShot 2023-03-15 at 10 42 23](https://user-images.githubusercontent.com/28976199/225289670-66d3482d-ee15-4ff8-8db2-fd1957fe503c.png)
![CleanShot 2023-03-15 at 10 42 13](https://user-images.githubusercontent.com/28976199/225289708-d8d6aa0e-b3fb-4765-8e38-4c21c68b51ac.png)
