### PR TITLE
Update Page models to include Wagtail Page's content_panels

### DIFF
--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -125,8 +125,7 @@ class BlogIndexPage(Page):
     def serve_preview(self, request, mode_name):
         return self.serve(request)
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("intro"),
         InlinePanel("related_links", label="Related links"),
     ]
@@ -264,8 +263,7 @@ class BlogPage(Page):
     def type(self):
         return "BLOG POST"
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         InlinePanel("authors", label="Author", min_num=1),
         FieldPanel("date"),
         FieldPanel("body"),

--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -218,8 +218,7 @@ class HomePage(Page):
     class Meta:
         verbose_name = "Homepage"
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         MultiFieldPanel(
             [
                 FieldPanel("hero_intro_primary"),

--- a/tbx/events/models.py
+++ b/tbx/events/models.py
@@ -16,8 +16,7 @@ class EventIndexPage(Page):
     parent_page_types = ["torchbox.HomePage"]
     subpage_types = []
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         InlinePanel("events", label="events"),
     ]
 

--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -43,8 +43,7 @@ class PersonPage(Page):
         index.SearchField("biography"),
     ]
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("role"),
         FieldPanel("is_senior"),
         FieldPanel("intro"),
@@ -162,8 +161,7 @@ class CulturePage(Page):
         use_json_field=True,
     )
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("strapline"),
         FieldPanel("hero_image"),
         FieldPanel("intro"),
@@ -272,8 +270,7 @@ class ValuesPage(Page):
         use_json_field=True,
     )
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("strapline"),
         FieldPanel("intro"),
         InlinePanel("values", heading="Values", label="Values"),

--- a/tbx/work/models.py
+++ b/tbx/work/models.py
@@ -138,8 +138,7 @@ class WorkPage(Page):
     def type(self):
         return "CASE STUDY"
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("client", classname="client"),
         InlinePanel("authors", label="Author", min_num=1),
         FieldPanel("date"),
@@ -247,8 +246,7 @@ class WorkIndexPage(Page):
     def serve_preview(self, request, mode_name):
         return self.serve(request)
 
-    content_panels = [
-        FieldPanel("title", classname="title"),
+    content_panels = Page.content_panels + [
         FieldPanel("intro"),
         FieldPanel("hide_popular_tags"),
     ]


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/tbxcom/tickets/424

Many of the page models which are inheriting from wagtail's Page models are declaring their own `content_panels` and manually including the field panel for the pages' `title` field instead of using Wagtail core's Page content_panels. 

This change prepends the customn `content_panels` with Page.content_panels and also remove the custom title field panel so we can use Wagtail's better default title field.