### PR TITLE
Fix proposition header image

### DIFF
--- a/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.html
+++ b/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    {% image page.image width-1920 as hero_image %}
+    {% image page.image fill-746x500 as hero_image %}
 
     {% include "patterns/molecules/hero/hero--proposition.html" with title=page.strapline desc=page.intro image=hero_image %}
 

--- a/tbx/static_src/sass/abstracts/_variables.scss
+++ b/tbx/static_src/sass/abstracts/_variables.scss
@@ -96,7 +96,8 @@ $breakpoints: (
     'large' '(min-width: 1023px)',
     'menu-break' '(min-width: 1255px)',
     'menu-break-larger' '(min-width: 1400px)',
-    'x-large' '(min-width: 1919px)'
+    'x-large' '(min-width: 1919px)',
+    'xx-large' '(min-width: 2559px)'
 );
 
 // --------------------------------- Grid Dimensions --------------------------------------

--- a/tbx/static_src/sass/abstracts/_variables.scss
+++ b/tbx/static_src/sass/abstracts/_variables.scss
@@ -96,8 +96,7 @@ $breakpoints: (
     'large' '(min-width: 1023px)',
     'menu-break' '(min-width: 1255px)',
     'menu-break-larger' '(min-width: 1400px)',
-    'x-large' '(min-width: 1919px)',
-    'xx-large' '(min-width: 2559px)'
+    'x-large' '(min-width: 1919px)'
 );
 
 // --------------------------------- Grid Dimensions --------------------------------------

--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -117,17 +117,13 @@
                 padding-top: ($gutter * 3);
             }
         }
-        #{$root}__image-mask {
-            top: 140px;
-        }
     }
 
+    // The following code for image & image-mask is only used on proposition pages currently
     &__image {
         display: block;
         margin-top: -25px;
-        max-width: 100%;
         max-height: 50vh;
-        object-fit: cover;
 
         @include media-query(xx-large) {
             max-height: 20vh;
@@ -138,7 +134,7 @@
         @include z-index(zero);
         display: none;
         position: absolute;
-        top: -60px;
+        top: 140px;
         right: -50px;
         width: 45vw;
         height: auto;

--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -125,7 +125,13 @@
     &__image {
         display: block;
         margin-top: -25px;
-        width: 100%;
+        max-width: 100%;
+        max-height: 50vh;
+        object-fit: cover;
+
+        @include media-query(xx-large) {
+            max-height: 20vh;
+        }
     }
 
     &__image-mask {

--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -115,6 +115,7 @@
             @include media-query(large) {
                 padding-right: 45vw;
                 padding-top: ($gutter * 3);
+                min-height: 415px; // to ensure image doesn't overlap hero area if text is shorter
             }
         }
     }
@@ -123,17 +124,14 @@
     &__image {
         display: block;
         margin-top: -25px;
-        max-height: 50vh;
-
-        @include media-query(xx-large) {
-            max-height: 20vh;
-        }
+        width: 100%;
     }
 
     &__image-mask {
         @include z-index(zero);
         display: none;
         position: absolute;
+        max-height: 500px;
         top: 140px;
         right: -50px;
         width: 45vw;


### PR DESCRIPTION
https://torchbox.monday.com/boards/1192293412/views/4019870/pulses/1193034463

### **Changes included in this MR:**

- ensures the proposition header image does not expand out of its container
- adds a new breakpoint to make sure the header image looks good on wider screens (QHD +)

Note: I was thinking to add an additional breakpoint for screens with QHD < resolution < 4K and set it to 30vh, but that might be an overkill. Please let me know what you think.

### **To test**

On a local build visit the proposition page and see how the image behaves at various resolutions

### **Screenshots**

1920*1200

![Screen Shot 2023-06-13 at 16 03 18 PM](https://github.com/torchbox/wagtail-torchbox/assets/51043550/54b8a61a-e12c-403e-b21c-dc57f37d4d45)

2560*1440 (QHD)

![Screen Shot 2023-06-13 at 16 04 18 PM](https://github.com/torchbox/wagtail-torchbox/assets/51043550/41067708-6e9d-4451-9194-c23dff2ebf19)

3840*1260 (4K)

![Screen Shot 2023-06-13 at 16 04 46 PM](https://github.com/torchbox/wagtail-torchbox/assets/51043550/f00bba0a-06cb-4a85-9655-015e3e4b9c00)

5120*2160 (5K)

![Screen Shot 2023-06-13 at 16 05 04 PM](https://github.com/torchbox/wagtail-torchbox/assets/51043550/712b9af9-a864-408c-94ee-dee1aeb8ecf8)

