### PR TITLE
Secondary footer alignement

### DIFF
--- a/tbx/static_src/sass/components/_footer.scss
+++ b/tbx/static_src/sass/components/_footer.scss
@@ -88,7 +88,8 @@
         @include media-query(menu-break) {
             margin-top: 0;
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
+            grid-template-columns: 2fr 1fr;
+            align-items: baseline;
         }
     }
 
@@ -129,6 +130,7 @@
     &__appendix {
         display: flex;
         flex-direction: column;
+        align-items: baseline;
         margin-left: 10px;
 
         @include media-query(large) {
@@ -182,6 +184,10 @@
         display: flex;
         align-items: center;
         justify-content: center;
+
+        @include media-query(menu-break) {
+            justify-content: end;
+        }
     }
 
     &__social-icon {


### PR DESCRIPTION
https://torchbox.monday.com/boards/1192293412/views/4019870/pulses/1210654603

### **Changes included in this MR:**

- grid structure changed to accommodate increased links list
- content aligned by baseline for a better look
- central position of social media links kept for smaller screens (<1255px)

### **Screenshots**
**Before**
![image](https://github.com/torchbox/wagtail-torchbox/assets/51043550/f6b1a8fa-c26e-4368-88f9-e73225809f8a)

**After**
![image](https://github.com/torchbox/wagtail-torchbox/assets/51043550/775755ea-59da-4261-8e05-ab947b147344)
