### PR TITLE
Reduce the hero image size on proposition pages

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/hero/hero--proposition.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/hero/hero--proposition.html
@@ -9,7 +9,7 @@
         </div>
         {% if image %}
             <div class="hero__image-mask">
-            <img class="hero__image" src="{{ image.url }}" alt="">
+                <img class="hero__image" src="{{ image.url }}" alt="">
             </div>
         {% endif %}
         {% include "patterns/molecules/in-page-nav/in-page-nav--proposition.html" with title=page.service %}

--- a/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.html
+++ b/tbx/project_styleguide/templates/patterns/pages/proposition/proposition.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    {% image page.image width-1920 as hero_image %}
+    {% image page.image fill-600x402 as hero_image %}
 
     {% include "patterns/molecules/hero/hero--proposition.html" with title=page.strapline desc=page.intro image=hero_image %}
 

--- a/tbx/static_src/sass/abstracts/_variables.scss
+++ b/tbx/static_src/sass/abstracts/_variables.scss
@@ -95,7 +95,8 @@ $breakpoints: (
     'medium' '(min-width: 599px)',
     'large' '(min-width: 1023px)',
     'menu-break' '(min-width: 1255px)',
-    'x-large' '(min-width: 1919px)'
+    'x-large' '(min-width: 1919px)',
+    'xx-large' '(min-width: 2559px)'
 );
 
 // --------------------------------- Grid Dimensions --------------------------------------

--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -117,17 +117,13 @@
                 padding-top: ($gutter * 3);
             }
         }
-        #{$root}__image-mask {
-            top: 140px;
-        }
     }
 
+    // The following code for image & image-mask is only used on proposition pages currently
     &__image {
         display: block;
         margin-top: -25px;
-        max-width: 100%;
         max-height: 50vh;
-        object-fit: cover;
 
         @include media-query(xx-large) {
             max-height: 20vh;
@@ -138,7 +134,7 @@
         @include z-index(zero);
         display: none;
         position: absolute;
-        top: -60px;
+        top: 140px;
         right: -50px;
         width: 45vw;
         height: auto;

--- a/tbx/static_src/sass/components/_hero.scss
+++ b/tbx/static_src/sass/components/_hero.scss
@@ -125,7 +125,13 @@
     &__image {
         display: block;
         margin-top: -25px;
-        width: 100%;
+        max-width: 100%;
+        max-height: 50vh;
+        object-fit: cover;
+
+        @include media-query(xx-large) {
+            max-height: 20vh;
+        }
     }
 
     &__image-mask {


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1192293412/views/4019870/pulses/1193034463

This builds on the work done in  https://github.com/torchbox/wagtail-torchbox/pull/487 so includes the code changes from there.

My only addition is to change the image tag to make the rendition used in the template smaller - it also now uses a crop to get an image that is the correct aspect ratio for the mask surrounding it (although with images where the focus is to the right, the focus may be hidden).

I haven't included a screenshot, as this should hopefully not make any visual changes.