### PR TITLE
Add back default link colour for dark transparent theme, used on the home page

### DIFF
--- a/tbx/static_src/sass/components/_theme.scss
+++ b/tbx/static_src/sass/components/_theme.scss
@@ -91,6 +91,7 @@ Icon colour used for:
         --color--primary: var(--color--white);
         --color--accent: var(--color--coral);
         --color--theme-link: var(--color--dark-indigo);
+        --color--link: var(--color--dark-indigo);
         --color--underline: var(--color--coral);
         --color--hover: var(--color--white);
         --color--theme-hover: var(--color--white);


### PR DESCRIPTION
There is no ticket for this currently

### Description of Changes Made

Fixes a bug whereby the blog links titles on the home page were coral instead of indigo.

When I did the theme fixes I accidentally removed the setting of `--color--link` for the 'dark transparent' theme

### How to Test

Visit the home page in your local build with this branch checked out, and ensure the blog titles are the dark indigo colour.

### Screenshots

<details>
  <summary>Expand to see more</summary>

Before:
![Screenshot 2023-06-27 at 08 17 38](https://github.com/torchbox/wagtail-torchbox/assets/771869/7da51a1d-2ed2-41b4-ba53-5845f5f00de3)


After:
![Screenshot 2023-06-27 at 08 17 11](https://github.com/torchbox/wagtail-torchbox/assets/771869/d29ae222-53e1-471b-8452-1172d17e417b)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
