### PR TITLE
Fixes to the badge colour and hover state in different themes

### DIFF
--- a/tbx/static_src/sass/components/_badge.scss
+++ b/tbx/static_src/sass/components/_badge.scss
@@ -12,12 +12,16 @@
         width: 18px;
         height: 22px;
         content: '';
-        background: var(--color--header-icon-color);
+        background: var(--color--accent);
         position: absolute;
         transform: translate(-50%, -25%) rotate(30deg);
         left: 50%;
         top: 0;
         transition: background $transition;
+
+        @include media-query(menu-break) {
+            background: var(--color--header-icon-color);
+        }
     }
 
     &:focus,

--- a/tbx/static_src/sass/components/_badge.scss
+++ b/tbx/static_src/sass/components/_badge.scss
@@ -12,24 +12,36 @@
         width: 18px;
         height: 22px;
         content: '';
-        background: var(--color--accent);
+        background-color: var(--color--accent);
         position: absolute;
         transform: translate(-50%, -25%) rotate(30deg);
         left: 50%;
         top: 0;
-        transition: background $transition;
+        transition: background-color $transition;
 
         @include media-query(menu-break) {
-            background: var(--color--header-icon-color);
+            background-color: var(--color--header-icon-color);
         }
     }
 
     &:focus,
     &:hover {
-        color: var(--color--accent);
+        color: var(--color--dark-indigo);
+
+        @include media-query(menu-break) {
+            color: var(--color--white);
+        }
 
         &::before {
-            background: var(--color--primary);
+            background-color: var(--color--white);
+
+            @include media-query(menu-break) {
+                background-color: var(--color--dark-indigo);
+
+                .theme--coral & {
+                    background-color: var(--color--coral);
+                }
+            }
         }
     }
 
@@ -41,13 +53,6 @@
     .mobile-nav & {
         &::before {
             top: 3px;
-        }
-    }
-
-    .theme--coral & {
-        &:focus,
-        &:hover {
-            color: var(--color--dark-indigo);
         }
     }
 


### PR DESCRIPTION
[Monday ticket
](https://torchbox.monday.com/boards/1192293412/views/4019870)

### Description of Changes Made
Another little theme bugfix. I spotted that the mobile dropdown in the coral theme was not displaying the jobs badge as the fill colour was the same as the background colour. I then spotted that the hover effects on the badges aren't great either.

### How to Test
Visit a page using the coral theme in your local build, reduce the screen size, and open the mobile drop-down menu to see the badge colour. Check the hover state too, and compare it to the colour and hover state in the desktop dropdown.

Repeat this for the other themes - compare to the live site to see the differences.

Check the badge colour and hover state in the dropdown menu on the home page, and compare to live to confirm this has not changed.

### Before and after screencasts

<details>
  <summary>Expand to see more</summary>

https://github.com/torchbox/wagtail-torchbox/assets/771869/53dc5643-910a-4a26-8993-3cdacf381129


https://github.com/torchbox/wagtail-torchbox/assets/771869/ba6bb73c-3068-4958-8a59-33c392c94c29


</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
