### PR TITLE
Tweaks to the styling for footer links at mobile

### DIFF
--- a/tbx/static_src/sass/components/_footer.scss
+++ b/tbx/static_src/sass/components/_footer.scss
@@ -158,7 +158,8 @@
     &__links {
         display: flex;
         flex-wrap: wrap;
-        gap: $grid;
+        column-gap: $grid;
+        row-gap: $grid / 2;
         margin-top: $grid / 5;
         align-items: center;
 

--- a/tbx/static_src/sass/components/_footer.scss
+++ b/tbx/static_src/sass/components/_footer.scss
@@ -147,32 +147,32 @@
         @include font-size(xxs);
         color: var(--color--grey);
         margin: ($grid * 2) 0 0 0;
+        display: flex;
+        align-items: center;
 
         @include media-query(menu-break) {
-            margin: 6px $grid 0 0;
+            margin: 0 $grid 0 0;
         }
     }
 
     &__links {
-        @include media-query(large) {
-            margin-bottom: $grid * 1.5;
-        }
+        display: flex;
+        flex-wrap: wrap;
+        gap: $grid;
+        margin-top: $grid / 5;
+        align-items: center;
 
         @include media-query(menu-break) {
             margin-bottom: 0;
+            margin-top: 0;
         }
     }
 
     &__link {
         @include font-size(xxs);
         display: inline-block;
-        margin-left: $grid;
         color: var(--color--indigo);
         border-bottom: 0;
-
-        &:first-child {
-            margin-left: 0;
-        }
 
         &:hover,
         &:focus {


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/4019870)

### Description of Changes Made
I made the updates to the footer link alignment on the careers site, and James H suggested some improvements at mobile which I'm porting back here

### How to Test
Check out this branch, and view the footer links at mobile in your local build (on any page)

### Screenshots

<details>
  <summary>Expand to see more</summary>

Note I have improved the vertical spacing since making the screenshots - it is now 10px for row-gap and 20px for column-gap

![Screenshot 2023-06-28 at 12 25 22](https://github.com/torchbox/wagtail-torchbox/assets/771869/dd06a84c-66ef-49b0-887f-004a3861efd0)

![Screenshot 2023-06-28 at 12 25 14](https://github.com/torchbox/wagtail-torchbox/assets/771869/9af87ec0-0ae6-4738-8bc2-869350f80abf)

![Screenshot 2023-06-28 at 12 25 00](https://github.com/torchbox/wagtail-torchbox/assets/771869/706d4733-1492-494d-83da-c7d37ec24b7f)
</details>



### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
    - Desktop: Chrome, Firefox and Edge
    - Mobile: iphone and android phone on browserstack
