### PR TITLE
Add django debug toolbar to dev

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2776,4 +2776,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "08b99b03c0c181628e67cf3695c15bae67e0bb562663a58d00dffbfea4127cd4"
+content-hash = "f42d7af91a801017404b3711d36d0be0361d9eaadb193d639885d8188e1fad05"

--- a/poetry.lock
+++ b/poetry.lock
@@ -565,6 +565,21 @@ jinja2 = ["jinja2 (>=2.9.6)"]
 tests = ["jinja2 (>=2.9.6)", "mock (==1.0.1)", "pep8 (==1.4.6)", "pytest (<4.0)", "pytest-django", "pytest-flakes (==1.0.1)", "pytest-pep8 (==1.0.6)", "six (==1.12.0)"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "4.1.0"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_debug_toolbar-4.1.0-py3-none-any.whl", hash = "sha256:a0b532ef5d52544fd745d1dcfc0557fa75f6f0d1962a8298bd568427ef2fa436"},
+    {file = "django_debug_toolbar-4.1.0.tar.gz", hash = "sha256:f57882e335593cb8e74c2bda9f1116bbb9ca8fc0d81b50a75ace0f83de5173c7"},
+]
+
+[package.dependencies]
+django = ">=3.2.4"
+sqlparse = ">=0.2"
+
+[[package]]
 name = "django-extensions"
 version = "3.2.1"
 description = "Extensions for Django"
@@ -2761,4 +2776,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8ad151cf8779c6f2ffbb680632c0b8c6570b31220b57955248e4f5b65ea87443"
+content-hash = "08b99b03c0c181628e67cf3695c15bae67e0bb562663a58d00dffbfea4127cd4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ django-birdbath = "^1.1.0"
 sentry-sdk = "^1.12.1"
 Wand = "^0.6.10"
 wagtailmedia = "^0.14.2"
+django-debug-toolbar = "^4.1.0"
 
 [tool.poetry.extras]
 gunicorn = ["gunicorn"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ django-birdbath = "^1.1.0"
 sentry-sdk = "^1.12.1"
 Wand = "^0.6.10"
 wagtailmedia = "^0.14.2"
-django-debug-toolbar = "^4.1.0"
 
 [tool.poetry.extras]
 gunicorn = ["gunicorn"]
 
 [tool.poetry.dev-dependencies]
 Werkzeug = "^2.1.2"
+django-debug-toolbar = "^4.1.0"
 django-extensions = "^3.2.1"
 fabric = "~2.5"
 stellar = "^0.4.5"

--- a/tbx/settings/dev.py
+++ b/tbx/settings/dev.py
@@ -32,6 +32,21 @@ PREVIEW_URL = "http://localhost:8003/preview/"
 
 MEDIA_PREFIX = WAGTAILADMIN_BASE_URL
 
+# Adds Django Debug Toolbar
+INSTALLED_APPS.append("debug_toolbar")  # noqa
+MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")  # noqa
+
+# Override in `local.py`
+SHOW_TOOLBAR = True
+
+DEBUG_TOOLBAR_CONFIG = {
+    # The default debug_toolbar_middleware.show_toolbar function checks whether the
+    # request IP is in settings.INTERNAL_IPS. In Docker, the request IP can vary, so
+    # we set it in settings.local instead.
+    "SHOW_TOOLBAR_CALLBACK": lambda x: SHOW_TOOLBAR,
+    "SHOW_COLLAPSED": True,
+}
+
 try:
     from .local import *  # noqa
 except ImportError:

--- a/tbx/settings/local.py.example
+++ b/tbx/settings/local.py.example
@@ -24,15 +24,5 @@ RECAPTCHA_PRIVATE_KEY = ''  # Private key
 # PATH_TO_WAGTAIL = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'wagtail')
 # sys.path.insert(1, PATH_TO_WAGTAIL)
 
-# INSTALLED_APPS += (
-#     'debug_toolbar',
-# )
-
-# MIDDLEWARE_CLASSES += (
-#     'debug_toolbar.middleware.DebugToolbarMiddleware',
-# )
-
-# django-debug-toolbar settings
-# DEBUG_TOOLBAR_CONFIG = {
-#     'INTERCEPT_REDIRECTS': False,
-# }
+# Show Django Debug Toolbar
+SHOW_TOOLBAR = True

--- a/tbx/urls.py
+++ b/tbx/urls.py
@@ -48,6 +48,12 @@ if settings.DEBUG:
         ),
     ]
 
+    # Django Debug Toolbar
+    if apps.is_installed("debug_toolbar"):
+        import debug_toolbar
+
+        urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+
 
 urlpatterns += [
     path("", include(torchbox_urls)),


### PR DESCRIPTION
(no ticket)

### Description of Changes Made

Add django debug toolbar for development. The project doesn't seem to have it set up by default for local dev. So I have added it based on how we do it on Wagtail kit.

### How to Test

Create a new local docker container with a copy of local.py.example. 

- `fab build`
- `fab start`
- `fab pull-staging-data`
- `fab sh`
  - `dj run_birdbath`
  - `honcho start`

View page on http://localhost:8000/ on the browser. It should have django debug toolbar enabled on the right side.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
