### PR TITLE
Make arrow smaller for 'read more' below client logo

### DIFF
--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -35,7 +35,7 @@
         border-bottom: 2px solid transparent; // prevent layout shift
 
         @include media-query(large) {
-            grid-template-rows: 1fr 10px;
+            grid-template-rows: 1fr 30px;
         }
     }
 

--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -35,7 +35,7 @@
         border-bottom: 2px solid transparent; // prevent layout shift
 
         @include media-query(large) {
-            grid-template-rows: 2fr 1fr;
+            grid-template-rows: 1fr 10px;
         }
     }
 
@@ -53,7 +53,7 @@
                 border-bottom: 2px solid transparent;
             }
 
-            // show CTA link only on desktop
+            // show CTA link on hover (only on desktop)
             @include media-query(large) {
                 &:focus,
                 &:hover {
@@ -98,7 +98,7 @@
                 display: block;
                 position: relative;
                 right: -5px;
-                top: 5px;
+                top: 7px;
                 flex-grow: 0;
                 flex-shrink: 0;
                 background-color: transparent;
@@ -106,8 +106,8 @@
                 transition: color $transition;
 
                 @include media-query(large) {
-                    width: 20px;
-                    height: 18px;
+                    width: 15px;
+                    height: 14px;
                 }
             }
         }


### PR DESCRIPTION
[Link to Ticket]()

### Description of Changes Made

Ticket: https://torchbox.monday.com/boards/1192293412/views/3284772/pulses/1222866298

This change makes the icon on the 'read more' link smaller (appears on hover for client logos on proposition pages).
There was also a request to move it up closer to the logos, but this isn't possible as the images are cropped with a large amount of white space. I have reduced the space below the row of logos and the text by changing the grid layout.

### How to Test

View a client logo with a link on a proposition page, and hover over it

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2023-08-01 at 13 46 30](https://github.com/torchbox/wagtail-torchbox/assets/771869/2fd8a2b2-ccba-46d1-bc1a-9aaef5299424)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
