### PR TITLE
Fix spacing below the image plus paragraph block (impact report page)

### DIFF
--- a/tbx/static_src/sass/components/_paragraph-with-image.scss
+++ b/tbx/static_src/sass/components/_paragraph-with-image.scss
@@ -24,7 +24,7 @@
         }
 
         @include media-query(medium) {
-            p:last-child {
+            > *:last-child {
                 margin-bottom: 0;
             }
         }

--- a/tbx/static_src/sass/components/_paragraph-with-image.scss
+++ b/tbx/static_src/sass/components/_paragraph-with-image.scss
@@ -1,6 +1,7 @@
 .paragraph-with-image {
     $root: &;
     gap: 30px;
+    margin-bottom: 30px;
 
     @include media-query(medium) {
         display: flex;
@@ -20,6 +21,12 @@
 
         a {
             @include impact-report-link-styles();
+        }
+
+        @include media-query(medium) {
+            p:last-child {
+                margin-bottom: 0;
+            }
         }
     }
 


### PR DESCRIPTION
[Fixes issue reported by Olly here](https://torchbox.monday.com/boards/1192293412/pulses/1244819479/posts/84460708)

### Description of Changes Made
The issue was actually the spacing below the "paragraph with image" block at mobile - at desktop the spacing below the bottom paragraph was creating a gap between this block and the one below, but only if the text was taller than the image. This fix adds a bottom margin to the whole block, then removes the bottom margin below the last element for desktop and above (below desktop a space is needed between the text and the image below).

Note that this block is only used on the impact report page.

### How to Test
Create an impact report page locally. Add a "paragraph with image" block, and test how it is spaced compared to the content below at both desktop and mobile.

### Screenshots

<details>
  <summary>Expand to see more</summary>

Before:
![Screenshot 2023-08-17 at 11 26 54](https://github.com/torchbox/wagtail-torchbox/assets/771869/9f74276d-54a2-44c3-ac89-8842fa32cfac)

After:
![Screenshot 2023-08-17 at 11 26 40](https://github.com/torchbox/wagtail-torchbox/assets/771869/efd09937-6174-4a76-8c87-b35d42eeacf9)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes. Chrome only - margin changes are pretty universal cross-browser.
