### PR TITLE
Draft: Add a background colour to impact report links in the hero

### DIFF
--- a/tbx/static_src/sass/components/_in-page-nav.scss
+++ b/tbx/static_src/sass/components/_in-page-nav.scss
@@ -190,6 +190,9 @@
 
             @include media-query(large) {
                 padding-top: 0;
+                padding-left: 2px;
+                padding-right: 2px;
+                background-color: rgba(255, 255, 255, 0.5);
             }
 
             &:focus,
@@ -219,6 +222,9 @@
 
             #{$root}__link {
                 padding-top: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                background-color: transparent;
 
                 &.is-active {
                     text-decoration-thickness: 5px;


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/4019870)

### Description of Changes Made
Adds a background colour to impact report links in the hero, but resets the changes when the page is scrolled and the navigation becomes stuck.

### How to Test
View an impact report page at desktop, and see there is a background colour making the links more legible when they overlay the image.

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2023-08-18 at 12 23 06](https://github.com/torchbox/wagtail-torchbox/assets/771869/5f0e6bb4-4889-4aa3-b0f6-62f2a643712d)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes. - Chrome on mac
