### PR TITLE
Impact report page headings and anchors adjustments

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/impact_report_heading_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/impact_report_heading_block.html
@@ -3,9 +3,11 @@
 <div class="report-section">
     {% image value.image fill-1792x597 class="report-section__image" %}
 
+    <div class="report-section__anchor" id="{{ value.short_heading|slugify }}" data-service-section></div>
+
     <div class="report-section__container">
         <div>
-            <p class="report-section__short-heading" id="{{ value.short_heading|slugify }}" data-service-section>
+            <p class="report-section__short-heading">
                 {{ value.short_heading }}
             </p>
         </div>

--- a/tbx/static_src/sass/components/_report-page.scss
+++ b/tbx/static_src/sass/components/_report-page.scss
@@ -44,7 +44,7 @@
 
         @include media-query(medium) {
             padding-top: 180px;
-            margin-top: -80px;
+            margin-top: -70px;
         }
     }
 

--- a/tbx/static_src/sass/components/_report-section.scss
+++ b/tbx/static_src/sass/components/_report-section.scss
@@ -1,8 +1,9 @@
 .report-section {
-    margin: 50px 0 10px;
+    margin: 80px 0 10px;
+    position: relative;
 
     @include media-query(medium) {
-        margin: 100px 0 20px;
+        margin: 130px 0 20px;
     }
 
     &__short-heading {
@@ -65,5 +66,14 @@
             max-width: 100%;
             grid-template-columns: 1fr 740px 1fr;
         }
+    }
+
+    &__anchor {
+        position: relative;
+        top: -200px;
+        padding-top: 125px; // compensate for nav height
+        margin-bottom: -125px;
+        width: 100%;
+        height: 0;
     }
 }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/4019870)

### Description of Changes Made
- Add more space above the heading image as requested by Olly
- Also as requested by Olly, adjust the markup and styles so that when you click on an anchor link, some of the header image shows above the heading. This also affects when the anchor links update on scroll in the sticky navigation.
- Fix an issue from testing on ipad where clicking on the intro link from the top meant that the sticky navigation did not appear

### How to Test
Create an impact report page and use the in page navigation and scroll up and down the page.

### Screenshots
Screen recording of the new behaviour:

https://github.com/torchbox/wagtail-torchbox/assets/771869/b44904ee-785c-430b-af1b-4305ab8d2700



<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes: chrome, edge, firefox and safari on mac. IOS and android on browserstack.
