### PR TITLE
Tweaks to the sticky nav breakpoints on the report page - refactor

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/hero/report_hero.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/hero/report_hero.html
@@ -8,20 +8,20 @@
         <div class="report-hero__content">
             <h1 class="report-hero__title">{{ title|richtext }}</h1>
         </div>
-        <nav class="in-page-nav in-page-nav--report" aria-label="In page navigation" data-in-page-nav>
-            <div class="in-page-nav__inner">
-                <div class="in-page-nav__header">
-                    <a href="#" title="Back to top" class="in-page-nav__back-to-top">
-                        <svg viewBox="0 0 130.37 156.35" aria-hidden="true" fill="var(--color--header-icon-color, #fd5765)" class="in-page-nav__logo"><path d="M129.64 82.82c-.2-1.59-2.3-1.96-3.08-.57-4.72 8.4-11.32 15.63-15.95 17.77l.03-.94C109.85 40.98 67.87 9.53 53.1.26c-1.39-.87-3.08.63-2.36 2.11 9.67 20.07 6.11 39.15-10.19 57.56-3.05 3.45-6.46 7.82-9.36 12.24v-.01s-3.48 5.06-6.84 12.09l-.16-.19c-6.73-10.16-8.2-22.44-8.47-29.08-.06-1.59-2.07-2.25-3-.95C8.53 59.86 1.31 71.61.24 84.57c-2.58 31.23 15.9 63.11 47.72 71.64 1.46.39 2.56-1.25 1.75-2.52-2.81-4.41-4.49-10.59-4.49-18.62 0-18.53 19.97-46.64 19.97-46.64s19.97 28.11 19.97 46.64c0 8.09-1.71 14.29-4.55 18.71-.81 1.26.27 2.9 1.73 2.52 30.86-7.96 45.44-36.5 47.64-53.99.78-7.79.24-14.95-.34-19.49z"></path></svg>
-                        <span class="in-page-nav__title">
+        <nav class="report-in-page-nav report-in-page-nav--report" aria-label="In page navigation" data-in-page-nav>
+            <div class="report-in-page-nav__inner">
+                <div class="report-in-page-nav__header">
+                    <a href="#" title="Back to top" class="report-in-page-nav__back-to-top">
+                        <svg viewBox="0 0 130.37 156.35" aria-hidden="true" fill="var(--color--header-icon-color, #fd5765)" class="report-in-page-nav__logo"><path d="M129.64 82.82c-.2-1.59-2.3-1.96-3.08-.57-4.72 8.4-11.32 15.63-15.95 17.77l.03-.94C109.85 40.98 67.87 9.53 53.1.26c-1.39-.87-3.08.63-2.36 2.11 9.67 20.07 6.11 39.15-10.19 57.56-3.05 3.45-6.46 7.82-9.36 12.24v-.01s-3.48 5.06-6.84 12.09l-.16-.19c-6.73-10.16-8.2-22.44-8.47-29.08-.06-1.59-2.07-2.25-3-.95C8.53 59.86 1.31 71.61.24 84.57c-2.58 31.23 15.9 63.11 47.72 71.64 1.46.39 2.56-1.25 1.75-2.52-2.81-4.41-4.49-10.59-4.49-18.62 0-18.53 19.97-46.64 19.97-46.64s19.97 28.11 19.97 46.64c0 8.09-1.71 14.29-4.55 18.71-.81 1.26.27 2.9 1.73 2.52 30.86-7.96 45.44-36.5 47.64-53.99.78-7.79.24-14.95-.34-19.49z"></path></svg>
+                        <span class="report-in-page-nav__title">
                             {{ title|richtext }}
                         </span>
                     </a>
                 </div>
-                <ul class="in-page-nav__container">
+                <ul class="report-in-page-nav__container">
                     {% for heading in page.headings %}
-                        <li class="in-page-nav__item">
-                            <a class="in-page-nav__link" href="#{{ heading.slug }}">{{ heading.short_heading }}</a>
+                        <li class="report-in-page-nav__item">
+                            <a class="report-in-page-nav__link" href="#{{ heading.slug }}">{{ heading.short_heading }}</a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/tbx/static_src/javascript/components/in-page-nav.js
+++ b/tbx/static_src/javascript/components/in-page-nav.js
@@ -9,7 +9,6 @@ class InPageNav {
         this.allSections = document.querySelectorAll('[data-service-section]');
         this.allMenuLinks = this.node.querySelectorAll('[data-in-page-nav] a');
         this.sentinelEl = document.getElementById('sentinel');
-        this.stickyClass = 'in-page-nav--stuck';
 
         this.initObserving();
         this.bindEvents();

--- a/tbx/static_src/sass/abstracts/_mixins.scss
+++ b/tbx/static_src/sass/abstracts/_mixins.scss
@@ -16,13 +16,6 @@
     }
 }
 
-// for one off media queries
-@mixin custom-media-query($query) {
-    @media only screen and #{$query} {
-        @content;
-    }
-}
-
 /* ============================================
     z-index
 */

--- a/tbx/static_src/sass/abstracts/_mixins.scss
+++ b/tbx/static_src/sass/abstracts/_mixins.scss
@@ -16,6 +16,13 @@
     }
 }
 
+// for one off media queries
+@mixin custom-media-query($query) {
+    @media only screen and #{$query} {
+        @content;
+    }
+}
+
 /* ============================================
     z-index
 */

--- a/tbx/static_src/sass/components/_report-in-page-nav.scss
+++ b/tbx/static_src/sass/components/_report-in-page-nav.scss
@@ -1,17 +1,26 @@
-.in-page-nav {
+// Based on the in-page-nav styles but there were enough variations
+// to justify a new version for the impact report page
+.report-in-page-nav {
     $root: &;
+    // the impact report page has a really custom breakpoint for the sticky nav which is
+    // purely based on the content used for the anchor links
+    $impact-report-breakpoint: '(min-width: 1280px)';
     @include z-index(in-page-nav);
     position: sticky;
     top: 0;
-    margin-left: 10.33vw;
+    margin-left: $variable-gutter--small;
 
-    &--proposition {
+    @include media-query(large) {
         margin-left: 0;
+    }
+
+    @include media-query(menu-break) {
+        margin-left: 10.33vw;
     }
 
     .nav-stuck & {
         #{$root}__inner {
-            background-color: var(--color--background);
+            background-color: var(--color--succulent);
             position: fixed;
             top: 0;
             left: 0;
@@ -19,7 +28,7 @@
             padding: ($gutter * 0.75) $variable-gutter--small;
             border-bottom: 1px solid var(--color--black-translucent);
 
-            @include media-query(large) {
+            @include custom-media-query($impact-report-breakpoint) {
                 display: flex;
                 align-items: center;
                 padding: $gutter $variable-gutter--small 0;
@@ -29,8 +38,10 @@
         #{$root}__container {
             margin-top: 0;
             padding-left: 0;
+            display: flex;
+            flex-wrap: wrap;
 
-            @include media-query(large) {
+            @include custom-media-query($impact-report-breakpoint) {
                 margin-left: 6.66vw;
             }
         }
@@ -38,12 +49,16 @@
         #{$root}__link {
             @include font-size(xxs);
             padding-bottom: 5px;
+            padding-top: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            background-color: transparent;
 
             &.is-active {
                 text-decoration-thickness: 5px;
             }
 
-            @include media-query(large) {
+            @include custom-media-query($impact-report-breakpoint) {
                 @include font-size(xs);
                 padding-bottom: 20px;
             }
@@ -53,7 +68,7 @@
             padding-bottom: 0;
             padding-right: 20px;
 
-            @include media-query(large) {
+            @include custom-media-query($impact-report-breakpoint) {
                 padding-right: 50px;
             }
         }
@@ -70,7 +85,7 @@
                 align-items: center;
             }
 
-            @include media-query(large) {
+            @include custom-media-query($impact-report-breakpoint) {
                 flex-shrink: 0;
                 margin-right: 55px;
                 margin-bottom: 14px;
@@ -81,18 +96,18 @@
     &__container {
         width: 100%;
         list-style: none;
-        display: flex;
-        margin-top: $gutter;
-        flex-wrap: wrap;
+        display: block;
+        padding-left: 0;
+        margin: 0;
 
         @include media-query(medium) {
-            padding-left: $variable-gutter--small;
             padding-top: 0;
             margin: 0;
         }
 
         @include media-query(large) {
-            padding-left: 0;
+            display: flex;
+            flex-wrap: wrap;
         }
     }
 
@@ -135,18 +150,17 @@
         align-items: center;
         position: relative;
         padding-right: 20px;
-        padding-bottom: 20px;
+        padding-bottom: 0;
 
         @include media-query(medium) {
-            padding-bottom: 0;
             padding-right: 50px;
         }
     }
 
     &__link {
-        font-size: map-get($small-font-sizes, xxs);
+        font-size: map-get($small-font-sizes, s);
         transition: border $transition-quick, color $transition-quick;
-        color: var(--color--theme-link);
+        color: var(--color--dark-indigo);
         text-decoration: underline;
         text-decoration-color: var(--color--underline);
         padding-top: 20px;
@@ -159,13 +173,16 @@
             color: var(--color--theme-hover);
         }
 
-        @include media-query(medium) {
-            font-size: map-get($medium-font-sizes, s);
-            padding: 0;
-        }
-
         @include media-query(large) {
-            font-size: map-get($large-font-sizes, s);
+            padding-top: 0;
+            padding-left: 2px;
+            padding-right: 2px;
+            background-color: rgba(255, 255, 255, 0.5);
+
+            &:focus,
+            &:hover {
+                border-bottom-color: var(--color--dark-indigo);
+            }
         }
     }
 }

--- a/tbx/static_src/sass/components/_report-in-page-nav.scss
+++ b/tbx/static_src/sass/components/_report-in-page-nav.scss
@@ -28,7 +28,7 @@
             padding: ($gutter * 0.75) $variable-gutter--small;
             border-bottom: 1px solid var(--color--black-translucent);
 
-            @include custom-media-query($impact-report-breakpoint) {
+            @media only screen and #{$impact-report-breakpoint} {
                 display: flex;
                 align-items: center;
                 padding: $gutter $variable-gutter--small 0;
@@ -41,7 +41,7 @@
             display: flex;
             flex-wrap: wrap;
 
-            @include custom-media-query($impact-report-breakpoint) {
+            @media only screen and #{$impact-report-breakpoint} {
                 margin-left: 6.66vw;
             }
         }
@@ -58,7 +58,7 @@
                 text-decoration-thickness: 5px;
             }
 
-            @include custom-media-query($impact-report-breakpoint) {
+            @media only screen and #{$impact-report-breakpoint} {
                 @include font-size(xs);
                 padding-bottom: 20px;
             }
@@ -68,7 +68,7 @@
             padding-bottom: 0;
             padding-right: 20px;
 
-            @include custom-media-query($impact-report-breakpoint) {
+            @media only screen and #{$impact-report-breakpoint} {
                 padding-right: 50px;
             }
         }
@@ -85,7 +85,7 @@
                 align-items: center;
             }
 
-            @include custom-media-query($impact-report-breakpoint) {
+            @media only screen and #{$impact-report-breakpoint} {
                 flex-shrink: 0;
                 margin-right: 55px;
                 margin-bottom: 14px;

--- a/tbx/static_src/sass/main.scss
+++ b/tbx/static_src/sass/main.scss
@@ -69,6 +69,7 @@
 @import 'components/related-content';
 @import 'components/related-item';
 @import 'components/report-hero';
+@import 'components/report-in-page-nav';
 @import 'components/report-page';
 @import 'components/report-section';
 @import 'components/section-title';


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/4019870)

### Description of Changes Made
Olly wanted the sticky navigation not to wrap on to two lines once the desktop styles (with the title to the left) are reached. We have to add a custom breakpoint that works with the final content on the live site which is as per this screenshot:

![Screenshot 2023-08-24 at 10 41 09](https://github.com/torchbox/wagtail-torchbox/assets/771869/f6ca7b2f-2817-4e6e-8d3b-95040f059c8e)

With the existing re-use of the `in-page-nav` styles, this would have meant first resetting the styles for the large breakpoint, then for the custom breakpoint - for the `--report` modifier only. We are already overriding the styles for the unstuck nav, so it was starting to get quite complex, and would be hard to adjust again in the future - we're likely to have different content next year. So I have split out the report sticky navigation styling into its own component - `report-in-page-nav` so that the overrides are clearer. I've made it easy to update the custom breakpoint in one place if we need to do so in the future.

### How to Test
Create an impact report page locally, and adjust the content of the headings as per the draft page on the live site (screenshot above)


### Screenshots

<details>
  <summary>Expand to see more</summary>

Current styles on staging below 1280px

![Screenshot 2023-08-24 at 10 45 34](https://github.com/torchbox/wagtail-torchbox/assets/771869/1a251c96-ac0f-4d25-8797-738f786092db)

New styles below 1280px

![Screenshot 2023-08-24 at 10 46 09](https://github.com/torchbox/wagtail-torchbox/assets/771869/9c6e0eb6-8ba2-4c76-9cae-47989d5f3322)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes. - chrome on mac.
