### PR TITLE
Fix alt text issues in impact report template

### DIFF
--- a/tbx/project_styleguide/templates/patterns/atoms/instagram-post/instagram-post.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/instagram-post/instagram-post.html
@@ -7,7 +7,7 @@
     {% elif post.image %}
         {% image post.image fill-500x500 as post_img %}
     {% endif %}
-    <img src="{{ post_img.url }}" class="instagram-post__image" width="500" height="500" loading="lazy" alt="View {% if post.value.link or post.link %}the post{% else %}more posts{% endif %} on Torchbox's Instagram page"  />
+    <img src="{{ post_img.url }}" class="instagram-post__image" width="500" height="500" loading="lazy" alt="{{ post_img.alt }}"  />
     <svg class="instagram-post__icon" viewBox="0 0 100 100" aria-hidden="true">
         <use xlink:href="#instagram" href="#instagram" />
     </svg>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/impact_report_heading_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/impact_report_heading_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags static %}
 
 <div class="report-section">
-    {% image value.image fill-1792x597 class="report-section__image" %}
+    {% image value.image fill-1792x597 class="report-section__image" alt="" %}
 
     <div class="report-section__anchor" id="{{ value.short_heading|slugify }}" data-service-section></div>
 

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/small_image_with_text_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/small_image_with_text_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="small-image-with-text">
-    {% image value.image fill-80x80 class="small-image-with-text__image" %}
+    {% image value.image fill-80x80 class="small-image-with-text__image" alt="" %}
 
     <div>
         <h4 class="small-image-with-text__title">{{ value.title }}</h4>


### PR DESCRIPTION
### Description of Changes Made

- Always mark impact report heading images as decorative
- Always mark "small images with text" as decorative
- Use images’ alt text for the instagram gallery, as currently all images contain text (and as such the alt text has to contain this text).

Since we’ve implemented this new page type and blocks without any capability to change the images’ default alt text or mark images as decorative image-by-image, we have to do this in the templates for all images of a given type.

### How to Test

Go through the impact report page and check for appropriate use of alt text.

### Screenshots

This won’t change the appearance of the relevant components, just the content for screen reader users.

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- ~~[ ] If your pull request is for a specific ticket, link to it in the description.~~
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- ~~[ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.~~ We generally don’t do this for alt text
- [x] Tests and linting passes.
- ~~[ ] Consider updating documentation. If you don't, tell us why.~~ No docs for this
- [x] If relevant, list the environments / browsers in which you tested your changes.

I’ve not tested this anywhere, just changing the templates in GitHub.
