### PR TITLE
Wagtail 5.0 fixes

### DIFF
--- a/tbx/impact_reports/models.py
+++ b/tbx/impact_reports/models.py
@@ -2,7 +2,12 @@ from django.db import models
 from django.utils.text import slugify
 
 from modelcluster.fields import ParentalKey
-from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
+from wagtail.admin.panels import (
+    FieldPanel,
+    InlinePanel,
+    MultiFieldPanel,
+    TitleFieldPanel,
+)
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Orderable, Page
 from wagtail.search import index
@@ -45,7 +50,7 @@ class ImpactReportPage(Page):
     content_panels = [
         MultiFieldPanel(
             [
-                FieldPanel("title", classname="title"),
+                TitleFieldPanel("title"),
                 FieldPanel("strapline"),
                 FieldPanel("hero_image"),
             ],

--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -417,6 +417,7 @@ class Author(index.Indexed, models.Model):
         return self.name
 
     search_fields = [
+        index.AutocompleteField("name"),
         index.SearchField("name"),
     ]
 
@@ -456,6 +457,7 @@ class Contact(index.Indexed, models.Model):
         return self.name
 
     search_fields = [
+        index.AutocompleteField("name"),
         index.SearchField("name"),
     ]
 


### PR DESCRIPTION
Parent PR: https://github.com/torchbox/wagtail-torchbox/pull/503

## Supplementary fixes:

Snippet choosers with searchable snippets were displaying the search box, but not returning any results when the user enters a search query. This is due to a change in internal behaviour:

[Wagtail 4.2](https://github.com/wagtail/wagtail/blob/v4.2.4/wagtail/admin/forms/choosers.py#L83-L95) used to fall back to a partial_match search if there was no autocomplete option available in the Snippet's .search_fields

[Wagtail 5.0](https://github.com/wagtail/wagtail/blob/v5.0/wagtail/admin/forms/choosers.py#L77-L79) expects there to be an AutocompleteField

The [release notes](https://docs.wagtail.org/en/stable/releases/5.0.html#elasticsearch-backend-no-longer-performs-partial-matching-on-search) allude to it, but don't quite make this clear. The fix is to make sure that your Snippet has an AutocompleteField configured, e.g:

```
search_fields = [
    index.AutocompleteField("title"), (added line)
    index.SearchField("title"),
]
```

- Need to run `update_index`