### PR TITLE
Hotfix for client logos

### DIFF
--- a/tbx/static_src/sass/components/_client-item.scss
+++ b/tbx/static_src/sass/components/_client-item.scss
@@ -65,7 +65,7 @@
 
     .streamfield & {
         width: 100%;
-        padding: 0;
+        padding: 0 0 25px;
 
         &::before {
             content: none; // don't show li arrow


### PR DESCRIPTION
Hotfix for client logos - allow a bit more space below to prevent the text cutting of

[Link to Ticket]()
No ticket - slack comms with Lisa

### Description of Changes Made
Ensure there is some bottom padding on the client logos.

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

Before:

<img width="235" alt="Screenshot 2023-10-12 at 11 30 46" src="https://github.com/torchbox/wagtail-torchbox/assets/771869/946bef6f-558c-49a0-96df-473dd63f22e0">

After:
<img width="243" alt="Screenshot 2023-10-12 at 11 41 32" src="https://github.com/torchbox/wagtail-torchbox/assets/771869/18f2a880-bc6f-4fc7-ace2-cb73e585f092">



</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
