### PR TITLE
Move people hr feed to an env var instead of using the jobs index page

### DIFF
--- a/tbx/core/context_processors.py
+++ b/tbx/core/context_processors.py
@@ -22,7 +22,7 @@ def peoplehr_jobs_count(request):
     if not job_count:
         peoplehr_feed = PeopleHRFeed()
         job_count = peoplehr_feed.get_job_count(settings.PEOPLEHR_FEED_URL)
-    cache.set(CACHE_KEY, job_count, CACHE_TIMEOUT)
+        cache.set(CACHE_KEY, job_count, CACHE_TIMEOUT)
 
     return {"job_count": job_count}
 

--- a/tbx/core/context_processors.py
+++ b/tbx/core/context_processors.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.core.cache import cache
 
 from tbx.core.api import PeopleHRFeed
-from tbx.core.models import JobIndexPage
 
 
 def fb_app_id(request):
@@ -21,13 +20,9 @@ def peoplehr_jobs_count(request):
     job_count = cache.get(CACHE_KEY)
 
     if not job_count:
-        job_index = JobIndexPage.objects.first()
-        if job_index:
-            peoplehr_feed = PeopleHRFeed()
-            job_count = peoplehr_feed.get_job_count(job_index.jobs_xml_feed)
-        else:
-            job_count = 0
-        cache.set(CACHE_KEY, job_count, CACHE_TIMEOUT)
+        peoplehr_feed = PeopleHRFeed()
+        job_count = peoplehr_feed.get_job_count(settings.PEOPLEHR_FEED_URL)
+    cache.set(CACHE_KEY, job_count, CACHE_TIMEOUT)
 
     return {"job_count": job_count}
 

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -568,3 +568,5 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserEmailAnonymiser",
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
+# people hr feed
+PEOPLEHR_FEED_URL = env.get("PEOPLEHR_FEED_URL"),

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -569,4 +569,4 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
 # people hr feed
-PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"),)
+PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"),) or '',

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -569,4 +569,4 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
 # people hr feed
-PEOPLEHR_FEED_URL = env.get("PEOPLEHR_FEED_URL"),
+PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"),)

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -569,4 +569,4 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
 # people hr feed
-PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"),) or '',
+PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"), ""),

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -569,4 +569,4 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
 # people hr feed
-PEOPLEHR_FEED_URL = (env.get("PEOPLEHR_FEED_URL"), ""),
+PEOPLEHR_FEED_URL = ((env.get("PEOPLEHR_FEED_URL"), ""),)

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -569,4 +569,4 @@ BIRDBATH_PROCESSORS = [
     "birdbath.processors.users.UserPasswordAnonymiser",
 ]
 # people hr feed
-PEOPLEHR_FEED_URL = ((env.get("PEOPLEHR_FEED_URL"), ""),)
+PEOPLEHR_FEED_URL = env.get("PEOPLEHR_FEED_URL", "")

--- a/tbx/settings/local.py.example
+++ b/tbx/settings/local.py.example
@@ -23,3 +23,6 @@ SECRET_KEY = 'enter-a-long-unguessable-string-here'
 
 # Show Django Debug Toolbar
 SHOW_TOOLBAR = True
+
+# people hr feed
+PEOPLEHR_FEED_URL = 'https://torchbox.peoplehr.net/Pages/JobBoard/CurrentOpenings.aspx?o=d7590cef-a34e-44d6-a930-4937c31e5e6b'


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/3284773/pulses/1297908290)

### Description of Changes Made
Previously the people hr feed url was fetched from a field in the jobs index page. Because this page was unpublished and had no visible function, Anna deleted it - this could easily happen again with another editor as it is not at all clear that the page is needed for code. Instead, this MR switches to an env var.

### How to Test
- check out the branch
- Make sure that the job_count cache is deleted on your local build, or temporarily comment out the cache code
- Copy the `PEOPLEHR_FEED_URL` variable in `local.py.example` to `local.py`
- Run your local build, and check that the job count displays in the drop-down on any wagtail page

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2023-10-20 at 10 00 51](https://github.com/torchbox/wagtail-torchbox/assets/771869/f53eb28f-d86d-45f0-8f03-bd48392e64e6)
</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
