### PR TITLE
fix to styling on sub-proposition page

### DIFF
--- a/tbx/static_src/sass/components/_quote-slider.scss
+++ b/tbx/static_src/sass/components/_quote-slider.scss
@@ -3,6 +3,11 @@
     grid-template-columns: auto 1fr;
     grid-template-rows: auto auto;
 
+    // On the sub-proposition page, when the quote is the first block in a section, add padding to compensate for the offset quote svg, so we don't overlap the absolutely positioned heading
+    .service-section .client-block__section:first-child & {
+        padding-top: 100px;
+    }
+
     &__icon {
         fill: var(--color--icon, var(--color--accent));
         width: 20vw;


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1299552042)

### Description of Changes Made

Fix the display of testimonials when they are the first child of a service section, so that they don't overlap the absolutely positioned title.

Note that this isn't very lovely code, but due to the way the styles are shared on the proposition and sub-proposition page, I'm not sure there is a better way.

### How to Test

On a sub-service page, add a "Testimonials / client logos" section, and add some testimonials at the top.
### Screenshots

<details>
  <summary>Expand to see more</summary>

Before:

![Screenshot 2023-10-23 at 13 10 37](https://github.com/torchbox/wagtail-torchbox/assets/771869/75e16795-77c8-4ce7-acaf-63ec7090829a)


After:
![Screenshot 2023-10-23 at 13 10 07](https://github.com/torchbox/wagtail-torchbox/assets/771869/60d5b779-b61f-45b7-bd86-8f2f52d7c8e6)


</details>



### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
