### PR TITLE
Use correct branch as the basis for deploying the docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -51,7 +51,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,13 +2,13 @@ name: Docs
 
 on:
   pull_request:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'docs/**/*'
       - 'mkdocs.yml'
 
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'docs/**/*'
       - 'mkdocs.yml'

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 This is the main website for torchbox.com, built on the [Wagtail CMS](https://wagtail.org/).
 
-To start working on this project, please refer to the README.
+To start working on this project, please refer to the [README](https://github.com/torchbox/wagtail-torchbox/blob/main/README.md).
 
 ## External integrations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Torchbox
 repo_url: https://github.com/torchbox/wagtail-torchbox
 site_url:
-edit_uri: 'edit/master/docs/'
+edit_uri: 'edit/main/docs/'
 
 repo_name: Github
 dev_addr: 0.0.0.0:8001


### PR DESCRIPTION
When the GitHub Actions configuration for the docs was initially defined, we had `master` as the default branch. We have since switched to `main`, but the configuration still maintained `master`. This PR corrects this.

### How to Test

We can only test this once we merge it to the `main` branch. I have made a rather minor edit to the docs (cae9aa93) just to trigger a GitHub Pages build when this PR is merged.

> **Note**
>
> a GitHub Pages build can also be invoked by running the **Docs** workflow manually from the [Actions tab](https://github.com/torchbox/wagtail-torchbox/actions)

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
