### PR TITLE
Entity Relationship Diagrams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,12 @@ ENV PATH=$VIRTUAL_ENV/bin:$PATH \
 ARG BUILD_ENV
 ENV BUILD_ENV=${BUILD_ENV}
 
+# install graphviz only in dev environment
+RUN if [ "$BUILD_ENV" = "dev" ] ; then \
+    apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
+    graphviz libgraphviz-dev \
+    && apt-get autoremove && rm -rf /var/lib/apt/lists/* ; \
+    fi
 
 # Port exposed by this container. Should default to the port used by your WSGI
 # server (Gunicorn). This is read by Dokku only. Heroku will ignore this.

--- a/poetry.lock
+++ b/poetry.lock
@@ -590,13 +590,13 @@ sqlparse = ">=0.2"
 
 [[package]]
 name = "django-extensions"
-version = "3.2.1"
+version = "3.2.3"
 description = "Extensions for Django"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "django-extensions-3.2.1.tar.gz", hash = "sha256:2a4f4d757be2563cd1ff7cfdf2e57468f5f931cc88b23cf82ca75717aae504a4"},
-    {file = "django_extensions-3.2.1-py3-none-any.whl", hash = "sha256:421464be390289513f86cb5e18eb43e5dc1de8b4c27ba9faa3b91261b0d67e09"},
+    {file = "django-extensions-3.2.3.tar.gz", hash = "sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a"},
+    {file = "django_extensions-3.2.3-py3-none-any.whl", hash = "sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401"},
 ]
 
 [package.dependencies]
@@ -1698,6 +1698,20 @@ files = [
 ]
 
 [[package]]
+name = "pydot"
+version = "1.4.2"
+description = "Python interface to Graphviz's Dot"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pydot-1.4.2-py2.py3-none-any.whl", hash = "sha256:66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451"},
+    {file = "pydot-1.4.2.tar.gz", hash = "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d"},
+]
+
+[package.dependencies]
+pyparsing = ">=2.1.4"
+
+[[package]]
 name = "pyflakes"
 version = "2.4.0"
 description = "passive checker of Python programs"
@@ -1721,6 +1735,16 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pygraphviz"
+version = "1.11"
+description = "Python interface to Graphviz"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pygraphviz-1.11.zip", hash = "sha256:a97eb5ced266f45053ebb1f2c6c6d29091690503e3a5c14be7f908b37b06f2d4"},
+]
 
 [[package]]
 name = "pymdown-extensions"
@@ -1780,6 +1804,20 @@ cryptography = ">=38.0.0,<40"
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.1.1"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+optional = false
+python-versions = ">=3.6.8"
+files = [
+    {file = "pyparsing-3.1.1-py3-none-any.whl", hash = "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb"},
+    {file = "pyparsing-3.1.1.tar.gz", hash = "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "python-dateutil"
@@ -2794,4 +2832,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "89f7743afdfbdc30b089cfb2155aa08841bbb073ad5b46ed9a70f868e871ad15"
+content-hash = "ccd8883420d4c7c03763fa195b4234b2e2fc1acc24fb9a9445dac0ea9618476f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.11"
 Django = "~4.2"
 wagtail = "~5.2"
 psycopg2 = "^2.9.3"
-gunicorn = {version = "^20.1.0", optional = true}
+gunicorn = { version = "^20.1.0", optional = true }
 django-pattern-library = "^1.1.0"
 whitenoise = "^6.1.0"
 dj-database-url = "^0.5.0"
@@ -37,11 +37,14 @@ gunicorn = ["gunicorn"]
 [tool.poetry.dev-dependencies]
 Werkzeug = "^2.1.2"
 django-debug-toolbar = "^4.1.0"
-django-extensions = "^3.2.1"
+django-extensions = "^3.2.3"
 fabric = "~2.5"
 stellar = "^0.4.5"
 pudb = "^2020.1"
 honcho = "^1.1.0"
+pygraphviz = "^1.11"
+pyparsing = "^3.1.1"
+pydot = "^1.4.2"
 
 # Linters etc.
 black = "^22.3.0"

--- a/tbx/settings/dev.py
+++ b/tbx/settings/dev.py
@@ -47,6 +47,8 @@ DEBUG_TOOLBAR_CONFIG = {
     "SHOW_COLLAPSED": True,
 }
 
+INSTALLED_APPS += ["django_extensions"]  # noqa
+
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
The changes introduced here allow for creating entity relationship diagrams via [django-extensions](https://django-extensions.readthedocs.io/en/latest/graph_models.html) and [graphviz](https://graphviz.org/).

This may be helpful in the early stages of the redesign, as we look at things such the field specification and harmonisation of field names / attrs between FE and BE.

The intention is not to merge this to the main branch, but rather to serve as reference. To be closed when no longer needed.

To generate a diagram:

1. checkout the `diagrams` branch and build the containers

    ```bash
    git checkout diagrams && \
    fab build
    ```
    
2. SSH into the `web` container

    ```bash
    fab ssh
    ```

3. In the container, run

   ```bash
	./manage.py graph_models \
	    blog \
	    events \
	    impact_reports \
	    navigation \
	    people \
	    propositions \
	    services \
	    sign_up_form \
	    taxonomy \
	    torchbox \
	    work \
	    images \
	    --pygraphviz --rankdir BT -o er_diagram.png
   ```

feel free to modify the above command as you please. See https://django-extensions.readthedocs.io/en/latest/graph_models.html#example-usage for usage examples.
