### PR TITLE
Update password required page styles

### DIFF
--- a/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
+++ b/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
@@ -5,11 +5,12 @@
 {% block body_class %}template-password-required{% endblock %}
 
 {% block content %}
-    <h1>Password required</h1>
+<div class="password-required">
+    <h1 class="password-required__title">Password required</h1>
 
-    <p class="heading--2">Please enter the password to proceed.</p>
+    <p>Please enter the password to proceed.</p>
 
-    <form action="{{ action_url }}" method="post">
+    <form class="password-required__form" action="{{ action_url }}" method="post">
         <div>
             {% csrf_token %}
 
@@ -22,7 +23,8 @@
             {% for field in form.hidden_fields %}
                 {{ field }}
             {% endfor %}
-            <input type="submit" value="Continue" />
         </div>
+        <input class="button password-required__submit-button" type="submit" value="Continue" />
     </form>
+</div>
 {% endblock %}

--- a/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
+++ b/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
@@ -5,26 +5,26 @@
 {% block body_class %}template-password-required{% endblock %}
 
 {% block content %}
-<div class="password-required">
-    <h1 class="password-required__title">Password required</h1>
+    <div class="password-required">
+        <h1 class="password-required__title">Password required</h1>
 
-    <p>Please enter the password to proceed.</p>
+        <p>Please enter the password to proceed.</p>
 
-    <form class="password-required__form" action="{{ action_url }}" method="post">
-        <div>
-            {% csrf_token %}
+        <form class="password-required__form" action="{{ action_url }}" method="post">
+            <div>
+                {% csrf_token %}
 
-            {{ form.non_field_errors }}
+                {{ form.non_field_errors }}
 
-            {{ form.password.errors }}
-            {{ form.password.label_tag }}
-            {{ form.password }}
+                {{ form.password.errors }}
+                {{ form.password.label_tag }}
+                {{ form.password }}
 
-            {% for field in form.hidden_fields %}
-                {{ field }}
-            {% endfor %}
-        </div>
-        <input class="button password-required__submit-button" type="submit" value="Continue" />
-    </form>
-</div>
+                {% for field in form.hidden_fields %}
+                    {{ field }}
+                {% endfor %}
+            </div>
+            <input class="button password-required__submit-button" type="submit" value="Continue" />
+        </form>
+    </div>
 {% endblock %}

--- a/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
+++ b/tbx/project_styleguide/templates/patterns/pages/wagtail/password_required.html
@@ -4,6 +4,8 @@
 
 {% block body_class %}template-password-required{% endblock %}
 
+{% block theme_class %}theme--light{% endblock %}
+
 {% block content %}
     <div class="password-required">
         <h1 class="password-required__title">Password required</h1>

--- a/tbx/static_src/sass/components/_password-required.scss
+++ b/tbx/static_src/sass/components/_password-required.scss
@@ -1,0 +1,31 @@
+.password-required {
+    padding: $grid;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+
+    &__title {
+        margin: 0 0 $grid 0;
+    }
+
+    &__form {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    &__submit-button {
+        width: max-content;
+        margin-top: $grid;
+        margin-bottom: $grid * 4;
+        padding: 10px 16px;
+        border: none;
+        cursor: pointer;
+
+        @include media-query(large) {
+            margin-top: $grid * 2;
+            margin-bottom: $grid * 6;
+        }
+    }
+}

--- a/tbx/static_src/sass/main.scss
+++ b/tbx/static_src/sass/main.scss
@@ -60,6 +60,7 @@
 @import 'components/page';
 @import 'components/paragraph-with-image';
 @import 'components/paragraph-with-quote';
+@import 'components/password-required';
 @import 'components/post';
 @import 'components/posts-grid';
 @import 'components/primary-nav';


### PR DESCRIPTION
### Description of Changes Made

Added basic styles to the password required page.

### How to Test

In Wagtail admin, click on the status tag for a page (the info icon in the top right of the editor menu) and set the page to private, accessible by password. Then try viewing the page. 

Note that this page style works best for the normal color scheme, when locking pages that use dark mode the logo and navigation menu are hidden. This template didn't support dark mode by default, this can be fixed in future work.

### Screenshots

<details>
  <summary>Expand to see more</summary>
<img width="590" alt="Screenshot 2024-02-21 at 14 12 19" src="https://github.com/torchbox/wagtail-torchbox/assets/18164832/3be5f820-a5e0-455d-b2c6-7575910afbcd">
<img width="1425" alt="Screenshot 2024-02-21 at 14 09 45" src="https://github.com/torchbox/wagtail-torchbox/assets/18164832/81997b05-a9a7-4b72-9051-c0275148e8f9">

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
